### PR TITLE
Rename DeepSeek V3 0324 Pro to DeepSeek V3 0324

### DIFF
--- a/packages/common/components/chat-input/chat-config.tsx
+++ b/packages/common/components/chat-input/chat-config.tsx
@@ -302,7 +302,7 @@ export const modelOptionsByProvider = {
             requiredApiKey: "OPENROUTER_API_KEY" as keyof ApiKeys,
         },
         {
-            label: "DeepSeek V3 0324 Pro",
+            label: "DeepSeek V3 0324",
             value: ChatMode.DEEPSEEK_V3_0324,
             webSearch: true,
             icon: undefined,

--- a/packages/shared/config/chat-mode.ts
+++ b/packages/shared/config/chat-mode.ts
@@ -405,7 +405,7 @@ export const getChatModeName = (mode: ChatMode) => {
             return "xAI Grok 4";
         // OpenRouter models
         case ChatMode.DEEPSEEK_V3_0324:
-            return "OpenRouter DeepSeek V3 0324 Pro";
+            return "OpenRouter DeepSeek V3 0324";
         case ChatMode.DEEPSEEK_R1:
             return "OpenRouter DeepSeek R1";
         case ChatMode.QWEN3_235B_A22B:


### PR DESCRIPTION
Hello,

I'm pretty sure Pro isn't part of the official model name, so just a minor typo fix