### PR TITLE
feat: switch deep research to gemini 2.5 flash

### DIFF
--- a/apps/web/app/help/faq/page.tsx
+++ b/apps/web/app/help/faq/page.tsx
@@ -208,7 +208,7 @@ function HelpCenterContent() {
                                     </li>
                                     <li className="text-muted-foreground">
                                         <strong>Deep Research:</strong> Comprehensive multi-step
-                                        research using Gemini 2.5 Pro for in-depth analysis (VT+
+                                        research using Gemini 2.5 Flash for in-depth analysis (VT+
                                         exclusive - 10 requests/day)
                                     </li>
                                     <li className="text-muted-foreground">

--- a/apps/web/app/help/page.tsx
+++ b/apps/web/app/help/page.tsx
@@ -213,7 +213,7 @@ function HelpCenterContent() {
                                     </li>
                                     <li className="text-muted-foreground">
                                         <strong>Deep Research:</strong> Comprehensive multi-step
-                                        research using Gemini 2.5 Pro for in-depth analysis (VT+
+                                        research using Gemini 2.5 Flash for in-depth analysis (VT+
                                         exclusive)
                                     </li>
                                     <li className="text-muted-foreground">

--- a/apps/web/app/tests/deep-research-model-id-fix.test.ts
+++ b/apps/web/app/tests/deep-research-model-id-fix.test.ts
@@ -52,12 +52,12 @@ describe("Deep Research Model ID Fix", () => {
 
     it("should record Deep Research requests with DEEP_RESEARCH model ID for VT+ users", async () => {
         const userId = "vt-plus-user-123";
-        const modelId = ModelEnum.GEMINI_2_5_PRO; // Used by Deep Research
+        const modelId = ModelEnum.GEMINI_2_5_FLASH; // Used by Deep Research
         const isVTPlusUser = true;
 
         await recordRequest(userId, modelId, isVTPlusUser);
 
-        // Verify recordProviderUsage was called with DEEP_RESEARCH instead of GEMINI_2_5_PRO
+        // Verify recordProviderUsage was called with DEEP_RESEARCH instead of GEMINI_2_5_FLASH
         expect(mockRecordProviderUsage).toHaveBeenCalledWith(
             userId,
             "DEEP_RESEARCH", // This should be the feature ID, not the model ID
@@ -97,7 +97,7 @@ describe("Deep Research Model ID Fix", () => {
 
     it("should record requests with original model ID for free users", async () => {
         const userId = "free-user-123";
-        const modelId = ModelEnum.GEMINI_2_5_PRO; // Used by Deep Research
+        const modelId = ModelEnum.GEMINI_2_5_FLASH; // Used by Deep Research
         const isVTPlusUser = false; // Free user
 
         await recordRequest(userId, modelId, isVTPlusUser);
@@ -105,7 +105,7 @@ describe("Deep Research Model ID Fix", () => {
         // Verify recordProviderUsage was called with the original model ID for free users
         expect(mockRecordProviderUsage).toHaveBeenCalledWith(
             userId,
-            ModelEnum.GEMINI_2_5_PRO, // Should remain as the original model ID for free users
+            ModelEnum.GEMINI_2_5_FLASH, // Should remain as the original model ID for free users
             "gemini",
         );
     });

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,6 +1,18 @@
 # Progress Log
 
-## Latest Session - January 2025
+## Latest Session - July 2025
+
+### ✅ Deep Research Model Update
+
+**Date**: Current Session (July 2025)
+**Status**: Completed
+
+- Switched Deep Research workflow to Gemini 2.5 Flash model
+- Updated tasks, model mapping, tests, and help docs
+
+---
+
+## Previous Session - January 2025
 
 ### ✅ useSession Runtime Error Fix
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -19,7 +19,7 @@ A flexible and powerful system for building AI agent workflows using a graph-bas
     - Fireworks
     - xAI
 - Specialized research workflows:
-    - Deep Research: Comprehensive analysis using Gemini 2.5 Pro
+    - Deep Research: Comprehensive analysis using Gemini 2.5 Flash
     - Pro Search: Fast web search using Gemini 2.5 Flash
 
 ## Getting Started

--- a/packages/ai/models.ts
+++ b/packages/ai/models.ts
@@ -277,7 +277,7 @@ export const models: Model[] = [
 export const getModelFromChatMode = (mode?: string): ModelEnum => {
     switch (mode) {
         case ChatMode.Deep:
-            return ModelEnum.GEMINI_2_5_PRO;
+            return ModelEnum.GEMINI_2_5_FLASH;
         case ChatMode.Pro:
             return ModelEnum.GEMINI_2_5_FLASH;
         case ChatMode.GEMINI_2_5_FLASH_LITE:

--- a/packages/ai/workflow/tasks/analysis.ts
+++ b/packages/ai/workflow/tasks/analysis.ts
@@ -75,7 +75,7 @@ ${getFormattingInstructions("analysis")}
         const mode = context?.get("mode") || "";
         // For Deep Research workflow, select available model with fallback mechanism
         const baseModel =
-            mode === ChatMode.Deep ? ModelEnum.GEMINI_2_5_PRO : getModelFromChatMode(mode);
+            mode === ChatMode.Deep ? ModelEnum.GEMINI_2_5_FLASH : getModelFromChatMode(mode);
         const model = selectAvailableModel(baseModel, context?.get("apiKeys"));
 
         const text = await generateText({

--- a/packages/ai/workflow/tasks/planner.ts
+++ b/packages/ai/workflow/tasks/planner.ts
@@ -72,7 +72,7 @@ export const plannerTask = createTask<WorkflowEventSchema, WorkflowContextSchema
         const mode = context?.get("mode") || "";
         // For Deep Research workflow, select available model with fallback mechanism
         const baseModel =
-            mode === ChatMode.Deep ? ModelEnum.GEMINI_2_5_PRO : getModelFromChatMode(mode);
+            mode === ChatMode.Deep ? ModelEnum.GEMINI_2_5_FLASH : getModelFromChatMode(mode);
         const model = selectAvailableModel(baseModel, context?.get("apiKeys"));
 
         // Determine VT+ feature based on mode

--- a/packages/ai/workflow/tasks/refine-query.ts
+++ b/packages/ai/workflow/tasks/refine-query.ts
@@ -107,7 +107,7 @@ export const refineQueryTask = createTask<WorkflowEventSchema, WorkflowContextSc
         const byokKeys = context?.get("apiKeys");
 
         // Select an appropriate model based on available API keys
-        const selectedModel = selectAvailableModel(ModelEnum.GEMINI_2_5_PRO, byokKeys);
+        const selectedModel = selectAvailableModel(ModelEnum.GEMINI_2_5_FLASH, byokKeys);
 
         // Determine VT+ feature based on mode
         const chatMode = context?.get("mode");

--- a/packages/ai/workflow/tasks/reflector.ts
+++ b/packages/ai/workflow/tasks/reflector.ts
@@ -100,7 +100,7 @@ Current date: ${getHumanizedDate()}
         const byokKeys = context?.get("apiKeys");
 
         // Select an appropriate model based on available API keys
-        const selectedModel = selectAvailableModel(ModelEnum.GEMINI_2_5_PRO, byokKeys);
+        const selectedModel = selectAvailableModel(ModelEnum.GEMINI_2_5_FLASH, byokKeys);
 
         // Determine VT+ feature based on mode
         const chatMode = context?.get("mode");

--- a/packages/ai/workflow/tasks/writer.ts
+++ b/packages/ai/workflow/tasks/writer.ts
@@ -112,7 +112,7 @@ ${getFormattingInstructions("writer")}
         const mode = context?.get("mode") || "";
         // For Deep Research workflow, select available model with fallback mechanism
         const baseModel =
-            mode === ChatMode.Deep ? ModelEnum.GEMINI_2_5_PRO : getModelFromChatMode(mode);
+            mode === ChatMode.Deep ? ModelEnum.GEMINI_2_5_FLASH : getModelFromChatMode(mode);
         const model = selectAvailableModel(baseModel, context?.get("apiKeys"));
 
         const answer = await generateText({

--- a/packages/shared/config/chat-mode.ts
+++ b/packages/shared/config/chat-mode.ts
@@ -427,7 +427,7 @@ export function getModelDisplayName(mode: string): string {
 export const getChatModeName = (mode: ChatMode) => {
     switch (mode) {
         case ChatMode.Deep:
-            return "Deep Research - Gemini 2.5 Pro";
+            return "Deep Research - Gemini 2.5 Flash";
         case ChatMode.Pro:
             return "Pro Search - Gemini 2.5 Flash";
         case ChatMode.GPT_4_1:


### PR DESCRIPTION
## Summary
- update Deep Research workflow to Gemini 2.5 Flash
- refresh help docs and tests for new Deep Research model
- log progress in memory bank

## Testing
- `bun run lint` *(fails: 869 warnings, 81 errors)*
- `bun run build` *(fails: script "build" exited with code 130)*
- `bun test` *(fails: DATABASE_URL environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_689ad0bc2dc88323af63f33b65922354