### PR TITLE
Update VT+ quota limits and documentation

### DIFF
--- a/apps/web/app/about/page.tsx
+++ b/apps/web/app/about/page.tsx
@@ -222,12 +222,12 @@ function AboutContent() {
                             <ul className='text-muted-foreground list-inside list-disc space-y-2'>
                                 <li>
                                     <strong>Deep Research:</strong>{' '}
-                                    Advanced research capabilities with comprehensive analysis - 10
+                                    Advanced research capabilities with comprehensive analysis - 25
                                     daily uses for VT+ subscribers
                                 </li>
                                 <li>
                                     <strong>Pro Search:</strong>{' '}
-                                    Enhanced search with web integration - 20 daily uses for VT+
+                                    Enhanced search with web integration - 50 daily uses for VT+
                                     subscribers
                                 </li>
                                 <li>

--- a/apps/web/app/help/faq/page.tsx
+++ b/apps/web/app/help/faq/page.tsx
@@ -210,12 +210,12 @@ function HelpCenterContent() {
                                     <li className='text-muted-foreground'>
                                         <strong>Deep Research:</strong>{' '}
                                         Comprehensive multi-step research using Gemini 2.5 Flash for
-                                        in-depth analysis (VT+ exclusive - 10 requests/day)
+                                        in-depth analysis (VT+ exclusive - 25 requests/day)
                                     </li>
                                     <li className='text-muted-foreground'>
                                         <strong>Pro Search:</strong>{' '}
                                         Fast grounding web search using Gemini 2.5 Flash for quick
-                                        information retrieval (VT+ exclusive - 20 requests/day)
+                                        information retrieval (VT+ exclusive - 50 requests/day)
                                     </li>
                                     <li className='text-muted-foreground'>
                                         <strong>Document Processing:</strong>{' '}
@@ -293,12 +293,12 @@ function HelpCenterContent() {
                                 <ul className='mt-2 list-outside list-disc space-y-2 pl-4'>
                                     <li className='text-muted-foreground'>
                                         <strong>Pro Search:</strong>{' '}
-                                        Lightning-fast web search with AI grounding (20
+                                        Lightning-fast web search with AI grounding (50
                                         requests/day)
                                     </li>
                                     <li className='text-muted-foreground'>
                                         <strong>Deep Research:</strong>{' '}
-                                        Comprehensive multi-step research and analysis (10
+                                        Comprehensive multi-step research and analysis (25
                                         requests/day)
                                     </li>
                                 </ul>
@@ -363,12 +363,12 @@ function HelpCenterContent() {
                                         <strong>Deep Research (VT+ exclusive):</strong>{' '}
                                         Uses Gemini 2.5 Pro for comprehensive, multi-step research
                                         with detailed analysis and thorough investigation of complex
-                                        topics (10 requests/day)
+                                        topics (25 requests/day)
                                     </li>
                                     <li className='text-muted-foreground'>
                                         <strong>Pro Search (VT+ exclusive):</strong>{' '}
                                         Uses Gemini 2.5 Flash for fast, efficient web search and
-                                        information retrieval with quick grounding capabilities (20
+                                        information retrieval with quick grounding capabilities (50
                                         requests/day)
                                     </li>
                                     <li className='text-muted-foreground'>

--- a/apps/web/app/help/page.tsx
+++ b/apps/web/app/help/page.tsx
@@ -298,12 +298,12 @@ function HelpCenterContent() {
                                 <ul className='mt-2 list-outside list-disc space-y-2 pl-4'>
                                     <li className='text-muted-foreground'>
                                         <strong>Pro Search:</strong>{' '}
-                                        Lightning-fast web search with AI grounding - 20 requests
+                                        Lightning-fast web search with AI grounding - 50 requests
                                         per day
                                     </li>
                                     <li className='text-muted-foreground'>
                                         <strong>Deep Research:</strong>{' '}
-                                        Comprehensive multi-step research and analysis - 10 requests
+                                        Comprehensive multi-step research and analysis - 25 requests
                                         per day
                                     </li>
                                     <li className='text-muted-foreground'>
@@ -373,12 +373,12 @@ function HelpCenterContent() {
                                         <strong>Deep Research (VT+ exclusive):</strong>{' '}
                                         Uses Gemini 2.5 Pro for comprehensive, multi-step research
                                         with detailed analysis and thorough investigation of complex
-                                        topics - 10 requests per day
+                                        topics - 25 requests per day
                                     </li>
                                     <li className='text-muted-foreground'>
                                         <strong>Pro Search (VT+ exclusive):</strong>{' '}
                                         Uses Gemini 2.5 Flash for fast, efficient web search and
-                                        information retrieval with quick grounding capabilities - 20
+                                        information retrieval with quick grounding capabilities - 50
                                         requests per day
                                     </li>
                                     <li className='text-muted-foreground'>
@@ -410,12 +410,12 @@ function HelpCenterContent() {
                                 <ul className='mt-4 list-outside list-disc space-y-2 pl-4'>
                                     <li className='text-muted-foreground'>
                                         <strong>Deep Research:</strong>{' '}
-                                        10 requests per day for VT+ subscribers, 0 for base plan
+                                        25 requests per day for VT+ subscribers, 0 for base plan
                                         users
                                     </li>
                                     <li className='text-muted-foreground'>
                                         <strong>Pro Search:</strong>{' '}
-                                        20 requests per day for VT+ subscribers, 0 for base plan
+                                        50 requests per day for VT+ subscribers, 0 for base plan
                                         users
                                     </li>
                                     <li className='text-muted-foreground'>

--- a/apps/web/app/tests/vtplus-daily-limits.test.ts
+++ b/apps/web/app/tests/vtplus-daily-limits.test.ts
@@ -48,12 +48,12 @@ describe('VT+ Daily Limits', () => {
     describe('Configuration', () => {
         it('should set daily limits for Deep Research and Pro Search', () => {
             expect(VT_PLUS_LIMITS[VtPlusFeature.DEEP_RESEARCH]).toEqual({
-                limit: 5,
+                limit: 25,
                 window: 'daily',
             });
 
             expect(VT_PLUS_LIMITS[VtPlusFeature.PRO_SEARCH]).toEqual({
-                limit: 10,
+                limit: 50,
                 window: 'daily',
             });
         });
@@ -128,8 +128,8 @@ describe('VT+ Daily Limits', () => {
             expect(mockDb.select).toHaveBeenCalledTimes(1);
 
             // Verify correct limits are applied
-            expect(allUsage[VtPlusFeature.DEEP_RESEARCH].limit).toBe(5);
-            expect(allUsage[VtPlusFeature.PRO_SEARCH].limit).toBe(10);
+            expect(allUsage[VtPlusFeature.DEEP_RESEARCH].limit).toBe(25);
+            expect(allUsage[VtPlusFeature.PRO_SEARCH].limit).toBe(50);
         });
     });
 

--- a/docs/guides/vtplus-rate-limiting.md
+++ b/docs/guides/vtplus-rate-limiting.md
@@ -37,8 +37,8 @@ The VT+ rate limiting system provides quota-based access control for three premi
 
 | Feature       | Code | Default Limit | Reset Window      | Estimated Cost |
 | ------------- | ---- | ------------- | ----------------- | -------------- |
-| Deep Research | `DR` | 5 requests    | Daily (00:00 UTC) | ~$1-2/day      |
-| Pro Search    | `PS` | 10 requests   | Daily (00:00 UTC) | ~$2-3/day      |
+| Deep Research | `DR` | 25 requests   | Daily (00:00 UTC) | ~$1-2/day      |
+| Pro Search    | `PS` | 50 requests   | Daily (00:00 UTC) | ~$2-3/day      |
 
 **Important Changes:**
 
@@ -51,8 +51,8 @@ Override defaults with environment variables:
 
 ```bash
 # VT+ Rate Limiting Configuration
-VTPLUS_DAILY_LIMIT_DR=10      # Deep Research - requests per day
-VTPLUS_DAILY_LIMIT_PS=10     # Pro Search - requests per day
+VTPLUS_DAILY_LIMIT_DR=25      # Deep Research - requests per day
+VTPLUS_DAILY_LIMIT_PS=50     # Pro Search - requests per day
 
 # Legacy monthly limits (for backward compatibility)
 VTPLUS_LIMIT_DR=500          # Legacy: Deep Research monthly limit
@@ -66,12 +66,12 @@ VTPLUS_LIMIT_PS=800          # Legacy: Pro Search monthly limit
 **Updated Counting Logic:**
 
 - **Deep Research**: 1 quota unit per user request (regardless of internal API calls)
-  - Daily limit: 5 requests per day
+  - Daily limit: 25 requests per day
   - Resets every day at 00:00 UTC
   - Each research request consumes 1 unit from daily quota
 
 - **Pro Search**: 1 quota unit per user request
-  - Daily limit: 10 requests per day
+  - Daily limit: 50 requests per day
   - Resets every day at 00:00 UTC
   - Each search request consumes 1 unit from daily quota
 

--- a/memory-bank/2025-08-17-vtplus-quota-update.md
+++ b/memory-bank/2025-08-17-vtplus-quota-update.md
@@ -1,0 +1,24 @@
+# VT+ Quota Update - August 17, 2025
+
+## Summary
+- Increased daily quotas for VT+ exclusive features:
+  - Pro Search: 50 requests/day (was 20)
+  - Deep Research: 25 requests/day (was 10)
+- Updated all public docs and pages to reflect new limits.
+- Synchronized default configuration and tests with new quotas.
+
+## Files Updated
+- `packages/shared/config/terms.ts`
+- `packages/shared/config/privacy.ts`
+- `apps/web/app/about/page.tsx`
+- `apps/web/app/help/page.tsx`
+- `apps/web/app/help/faq/page.tsx`
+- `docs/guides/vtplus-rate-limiting.md`
+- `packages/common/src/config/vtPlusLimits.ts`
+- `packages/common/__tests__/vtplus-config.test.ts`
+- `packages/common/__tests__/vtplus-limits-config.test.ts`
+- `apps/web/app/tests/vtplus-daily-limits.test.ts`
+
+## Impact
+- Documentation and configuration now accurately describe current VT+ feature quotas.
+- Tests aligned with new defaults.

--- a/packages/common/__tests__/vtplus-config.test.ts
+++ b/packages/common/__tests__/vtplus-config.test.ts
@@ -12,11 +12,11 @@ describe('VT+ Configuration', () => {
     describe('VT+ Limits', () => {
         it('should have correct default limits with windows', () => {
             expect(VT_PLUS_LIMITS[VtPlusFeature.DEEP_RESEARCH]).toEqual({
-                limit: 10,
+                limit: 25,
                 window: QUOTA_WINDOW.DAILY,
             });
             expect(VT_PLUS_LIMITS[VtPlusFeature.PRO_SEARCH]).toEqual({
-                limit: 20,
+                limit: 50,
                 window: QUOTA_WINDOW.DAILY,
             });
         });

--- a/packages/common/__tests__/vtplus-limits-config.test.ts
+++ b/packages/common/__tests__/vtplus-limits-config.test.ts
@@ -35,8 +35,8 @@ describe('VT+ Limits Configuration', () => {
 
         it('should use default values when env vars not set', () => {
             // Test the fallback logic directly
-            expect(Number(undefined) || 5).toBe(5);
-            expect(Number(undefined) || 10).toBe(10);
+            expect(Number(undefined) || 25).toBe(25);
+            expect(Number(undefined) || 50).toBe(50);
 
             // Verify current config has reasonable defaults
             expect(VT_PLUS_LIMITS[VtPlusFeature.DEEP_RESEARCH].limit).toBeGreaterThan(0);
@@ -151,11 +151,12 @@ describe('VT+ Limits Configuration', () => {
 
     describe('Budget considerations', () => {
         it('should have reasonable limits for budget constraints', () => {
-            const totalRequests = VT_PLUS_LIMITS[VtPlusFeature.DEEP_RESEARCH].limit
+            const totalRequests =
+                VT_PLUS_LIMITS[VtPlusFeature.DEEP_RESEARCH].limit
                 + VT_PLUS_LIMITS[VtPlusFeature.PRO_SEARCH].limit;
 
             // Daily limits should be reasonable for VT+ users
-            expect(totalRequests).toBeLessThanOrEqual(50);
+            expect(totalRequests).toBeLessThanOrEqual(100);
         });
 
         it('should have Deep Research limit lower than Pro Search', () => {

--- a/packages/common/src/config/vtPlusLimits.ts
+++ b/packages/common/src/config/vtPlusLimits.ts
@@ -28,11 +28,11 @@ export interface QuotaConfig {
  */
 export const VT_PLUS_LIMITS: Record<VtPlusFeature, QuotaConfig> = {
     [VtPlusFeature.DEEP_RESEARCH]: {
-        limit: parseInt(process.env.VTPLUS_DAILY_LIMIT_DR ?? '10', 10),
+        limit: parseInt(process.env.VTPLUS_DAILY_LIMIT_DR ?? '25', 10),
         window: QUOTA_WINDOW.DAILY,
     },
     [VtPlusFeature.PRO_SEARCH]: {
-        limit: parseInt(process.env.VTPLUS_DAILY_LIMIT_PS ?? '20', 10),
+        limit: parseInt(process.env.VTPLUS_DAILY_LIMIT_PS ?? '50', 10),
         window: QUOTA_WINDOW.DAILY,
     },
 };

--- a/packages/shared/config/privacy.ts
+++ b/packages/shared/config/privacy.ts
@@ -62,7 +62,7 @@ VT is built with **privacy-first principles** at its core:
 - **Account Management:** Create and manage your account, authenticate users
 - **Free Model Management:** We monitor daily usage and enforce rate limits for our server-funded AI models to ensure fair access for all users.
 - **Subscription Management:** Process VT+ subscriptions and billing via Creem.io
-- **Feature Access:** Determine access to VT+ exclusive research features with daily quotas (PRO_SEARCH: 20/day, DEEP_RESEARCH: 10/day) while providing all premium AI models free to logged-in users with BYOK
+- **Feature Access:** Determine access to VT+ exclusive research features with daily quotas (PRO_SEARCH: 50/day, DEEP_RESEARCH: 25/day) while providing all premium AI models free to logged-in users with BYOK
 - **Customer Support:** Respond to support requests within 24 hours via hello@vtchat.io.vn
 - **Service Communications:** Send important service updates, security alerts
 

--- a/packages/shared/config/terms.ts
+++ b/packages/shared/config/terms.ts
@@ -22,7 +22,7 @@ VT is an independent AI wrapper platform that provides user-friendly interfaces 
 - **Intelligent Tool Router**: AI-powered semantic routing automatically activates tools based on query intent
 - **Advanced Features**: Chart visualization, reasoning mode, document processing, web search integration
 - **Subscription Tiers**: VT_BASE (free) and VT_PLUS (premium) with clear feature differentiation
-- **Free Gemini Model**: All logged-in users get free access to a range of Gemini models, including 2.5 Flash Lite (20/day), 2.5 Flash (10/day), and 2.5 Pro (5/day), with daily request limits. VT+ users receive higher limits and access to expanded Gemini models plus exclusive research features (Pro Search: 20/day, Deep Research: 10/day).
+- **Free Gemini Model**: All logged-in users get free access to a range of Gemini models, including 2.5 Flash Lite (20/day), 2.5 Flash (10/day), and 2.5 Pro (5/day), with daily request limits. VT+ users receive higher limits and access to expanded Gemini models plus exclusive research features (Pro Search: 50/day, Deep Research: 25/day).
 - **Local Privacy**: Zero server-side storage of chat data for maximum privacy
 - **Mathematical Tools**: Built-in calculator with advanced mathematical functions
 - **Document Processing**: Upload and analyze various document formats (Free feature)
@@ -120,8 +120,8 @@ VT_BASE is our free tier for logged-in users that includes:
 VT+ is a monthly subscription service for **${VT_PLUS_PRICE_FORMATTED} USD** that includes:
 - **All Free Tier Features**: Complete access to all premium AI models and advanced features
 - **Two Exclusive Research Features with Daily Quotas**:
-  - **Enhanced Web Search (PRO_SEARCH)**: 20 requests per day (resets at 00:00 UTC)
-  - **Deep Research (DEEP_RESEARCH)**: 10 requests per day (resets at 00:00 UTC)
+  - **Enhanced Web Search (PRO_SEARCH)**: 50 requests per day (resets at 00:00 UTC)
+  - **Deep Research (DEEP_RESEARCH)**: 25 requests per day (resets at 00:00 UTC)
 - **Expanded Gemini Access**: VT+ subscribers receive expanded, server-funded access to all Gemini models, including Gemini 2.5 Pro (25 requests/day), Gemini 2.5 Flash (50 requests/day), and Gemini 2.5 Flash Lite (100 requests/day), all without needing your own API keys.
 - **Priority Support**: Enhanced customer support
 - **Daily Reset Schedule**: Pro Search and Deep Research quotas reset every day at 00:00 UTC to provide consistent daily usage


### PR DESCRIPTION
## Summary
- raise VT+ Pro Search quota to 50/day and Deep Research to 25/day across terms and policies
- update help center pages and configuration to reflect new quotas
- sync rate-limiting guide, default config, and tests with latest limits

## Testing
- `bun run fmt` *(fails: dprint not found)*
- `bun run format` *(fails: prettier-plugin-tailwindcss missing)*
- `bun run lint` *(fails: oxlint not found)*
- `bun run build` *(fails: turbo not found)*
- `bun test` *(fails: Cannot find module '@repo/shared/config', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a0548d3b888323b4e5134e6dc6626a