### PR TITLE
feat: add dynamic metadata for chat threads

### DIFF
--- a/apps/web/app/chat/[threadId]/layout.tsx
+++ b/apps/web/app/chat/[threadId]/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+
+const appName = process.env.NEXT_PUBLIC_APP_NAME || 'VT';
+
+type Props = {
+    params: Promise<{ threadId: string; }>;
+    children: ReactNode;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+    const { threadId } = await params;
+    return {
+        title: `Chat Thread ${threadId} | ${appName}`,
+        description: `Conversation ${threadId} on ${appName} AI platform`,
+    };
+}
+
+export function ThreadLayout({ children }: Props) {
+    return <>{children}</>;
+}
+
+export default ThreadLayout;

--- a/apps/web/app/chat/[threadId]/page.tsx
+++ b/apps/web/app/chat/[threadId]/page.tsx
@@ -2,7 +2,7 @@
 import { Footer, InlineLoader, TableOfMessages, Thread } from '@repo/common/components';
 import { useChatStore } from '@repo/common/store';
 import { useSession } from '@repo/shared/lib/auth-client';
-import { log } from '@repo/shared/logger';
+import { log } from '@repo/shared/lib/logger';
 import { Button } from '@repo/ui';
 import { ArrowLeft, Home } from 'lucide-react';
 import dynamic from 'next/dynamic';
@@ -26,9 +26,9 @@ const ChatInput = dynamic(
     },
 );
 
-const ChatSessionPage = (props: { params: Promise<{ threadId: string; }>; }) => {
-    const params = use(props.params);
-    const threadId = params.threadId;
+export function ChatSessionPage({ params }: { params: Promise<{ threadId: string; }>; }) {
+    const resolvedParams = use(params);
+    const threadId = resolvedParams.threadId;
     const router = useRouter();
     const { data: session, isPending } = useSession();
     const isGenerating = useChatStore((state) => state.isGenerating);
@@ -454,6 +454,6 @@ const ChatSessionPage = (props: { params: Promise<{ threadId: string; }>; }) => 
             </div>
         </div>
     );
-};
+}
 
 export default ChatSessionPage;

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useSession } from '@repo/shared/lib/auth-client';
-import log from '@repo/shared/logger';
+import { log } from '@repo/shared/lib/logger';
 import { TypographySmall } from '@repo/ui';
 import NextDynamic from 'next/dynamic';
 import { useEffect } from 'react';
@@ -49,7 +49,7 @@ const FooterWithSuspense = NextDynamic(
     },
 );
 
-export default function HomePage() {
+export function HomePage() {
     const { data: session, isPending } = useSession();
 
     // Log LCP optimization verification in development
@@ -66,9 +66,12 @@ export default function HomePage() {
             ].every((resource) => preloadHrefs.includes(resource));
 
             if (hasCriticalResources) {
-                log.info('✅ LCP: Critical resources are properly preloaded');
+                log.info({ lcp: 'preload-ok' }, 'Critical resources are properly preloaded');
             } else {
-                log.info('⚠️ LCP: Some critical resources may not be preloaded');
+                log.info(
+                    { lcp: 'preload-missing' },
+                    'Some critical resources may not be preloaded',
+                );
             }
         }
     }, []);
@@ -594,3 +597,5 @@ export default function HomePage() {
         </div>
     );
 }
+
+export default HomePage;

--- a/memory-bank/2025-02-14-metadata-thread-layout.md
+++ b/memory-bank/2025-02-14-metadata-thread-layout.md
@@ -1,0 +1,4 @@
+# Metadata Thread Layout
+
+- Added dynamic metadata generation for chat threads using Next.js `generateMetadata`.
+- Corrected Pino logger imports in home and chat thread pages.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,6 +1,16 @@
 # Progress Log
 
-## Latest Session - July 2025
+## Latest Session - February 2025
+
+### ✅ Chat Thread Metadata
+
+**Date**: Current Session (February 2025)
+**Status**: Completed
+
+- Added dynamic metadata generation for chat threads using Next.js `generateMetadata`.
+- Corrected Pino logger imports in home and thread pages.
+
+## Previous Session - July 2025
 
 ### ✅ Provider Logos Source Update
 


### PR DESCRIPTION
## Summary
- use `@repo/shared/lib/logger` and structured logging on home page
- add route-level `generateMetadata` for chat thread pages
- document thread metadata work in memory bank

## Testing
- `bun run fmt`
- `bun run lint` *(fails: eslint issues)*
- `bun run build` *(fails: Failed to collect page data for /api/admin/analytics)*
- `bun test` *(fails: Playwright test configuration errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a08f18a4f883239f43f795a33082a1