### PR TITLE
feat: paginate recent threads and expose entrypoints

### DIFF
--- a/apps/web/app/entrypoints/page.tsx
+++ b/apps/web/app/entrypoints/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { PublicRoutes } from '@repo/shared/constants/routes';
+import { TypographyH3, TypographyP } from '@repo/ui';
+import Link from 'next/link';
+
+enum EntryPointsText {
+    TITLE = 'Entrypoints',
+    DESCRIPTION = 'Quick access to core areas of the app',
+}
+
+enum EntryPointLabel {
+    CHAT = 'Chat',
+    RECENT = 'Recent Chats',
+    HELP = 'Help Center',
+    ABOUT = 'About',
+}
+
+const entryPointLinks = [
+    { href: PublicRoutes.HOME, label: EntryPointLabel.CHAT },
+    { href: PublicRoutes.RECENT, label: EntryPointLabel.RECENT },
+    { href: PublicRoutes.HELP, label: EntryPointLabel.HELP },
+    { href: PublicRoutes.ABOUT, label: EntryPointLabel.ABOUT },
+];
+
+export default function EntryPointsPage() {
+    return (
+        <div className='mx-auto flex w-full max-w-2xl flex-col gap-4 px-4 pt-16'>
+            <TypographyH3 className='font-clash text-brand tracking-wide'>
+                {EntryPointsText.TITLE}
+            </TypographyH3>
+            <TypographyP>{EntryPointsText.DESCRIPTION}</TypographyP>
+            <ul className='mt-2 flex flex-col gap-2'>
+                {entryPointLinks.map((link) => (
+                    <li key={link.href}>
+                        <Link className='text-primary underline' href={link.href}>
+                            {link.label}
+                        </Link>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}

--- a/apps/web/app/recent/page.tsx
+++ b/apps/web/app/recent/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { LoginRequiredDialog, useLoginRequired } from '@repo/common/components';
 import { useChatStore } from '@repo/common/store';
+import { PublicRoutes } from '@repo/shared/constants/routes';
 import { useSession } from '@repo/shared/lib/auth-client';
 import { getFormatDistanceToNow } from '@repo/shared/utils';
 import {
@@ -17,7 +18,8 @@ import {
     TypographyP,
 } from '@repo/ui';
 import { CommandItem } from 'cmdk';
-import { Clock, MoreHorizontal, Plus, Trash2 } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Clock, MoreHorizontal, Plus, Trash2 } from 'lucide-react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -39,12 +41,50 @@ export default function ThreadsPage() {
     const { data: session } = useSession();
     const isSignedIn = !!session;
     const { showLoginPrompt, requireLogin, hideLoginPrompt } = useLoginRequired();
+    enum EnvVar {
+        PAGE_SIZE = 'NEXT_PUBLIC_RECENT_PAGE_SIZE',
+    }
+    const threadsPerPage = Number(process.env[EnvVar.PAGE_SIZE]) || 10;
+    const [currentPage, setCurrentPage] = useState(1);
+    const totalPages = Math.ceil(threads.length / threadsPerPage) || 1;
+    const paginatedThreads = threads.slice(
+        (currentPage - 1) * threadsPerPage,
+        currentPage * threadsPerPage,
+    );
+    enum PaginationText {
+        PAGE = 'Page',
+        OF = 'of',
+    }
+    enum RecentPageText {
+        TITLE = 'Chat History',
+        SEARCH = 'Search',
+        NO_THREADS = 'No threads found',
+        START_THREAD = 'Start a new conversation to create a thread',
+        NEW_THREAD = 'New Thread',
+    }
+    enum AriaLabel {
+        PREV_PAGE = 'Previous page',
+        NEXT_PAGE = 'Next page',
+    }
+    enum ThreadDefaults {
+        UNTITLED = 'Untitled',
+    }
+    enum LinkText {
+        ENTRYPOINTS = 'Entrypoints',
+    }
+    enum Routes {
+        CHAT_BASE = '/chat',
+    }
 
     useEffect(() => {
         if (editingId && inputRef.current) {
             inputRef.current.focus();
         }
     }, [editingId]);
+
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [threads.length]);
 
     const handleEditClick = (threadId: string, threadTitle: string, e: React.MouseEvent) => {
         e.stopPropagation();
@@ -60,7 +100,7 @@ export default function ThreadsPage() {
         if (editingId) {
             updateThread({
                 id: editingId,
-                title: title?.trim() || 'Untitled',
+                title: title?.trim() || ThreadDefaults.UNTITLED,
             });
             setEditingId(null);
         }
@@ -70,7 +110,7 @@ export default function ThreadsPage() {
         if (e.key === 'Enter' && editingId) {
             updateThread({
                 id: editingId,
-                title: title?.trim() || 'Untitled',
+                title: title?.trim() || ThreadDefaults.UNTITLED,
             });
             setEditingId(null);
         }
@@ -88,7 +128,7 @@ export default function ThreadsPage() {
     };
 
     const handleThreadClick = (threadId: string) => {
-        push(`/chat/${threadId}`);
+        push(`${Routes.CHAT_BASE}/${threadId}`);
         switchThread(threadId);
     };
 
@@ -96,18 +136,21 @@ export default function ThreadsPage() {
         <div className='flex w-full flex-col gap-2'>
             <div className='mx-auto flex w-full max-w-2xl flex-col items-start gap-2 px-4 pt-16 md:px-0'>
                 <TypographyH3 className='font-clash text-brand tracking-wide'>
-                    Chat History
+                    {RecentPageText.TITLE}
                 </TypographyH3>
+                <Link className='text-primary underline text-sm' href={PublicRoutes.ENTRYPOINTS}>
+                    {LinkText.ENTRYPOINTS}
+                </Link>
                 <Command className='!max-h-auto bg-secondary w-full'>
                     <CommandInput
                         className='bg-tertiary rounded-xs h-8 w-full'
-                        placeholder='Search'
+                        placeholder={RecentPageText.SEARCH}
                     />
 
                     <CommandList className='bg-secondary mt-2 !max-h-none gap-2'>
                         {threads?.length > 0
                             ? (
-                                threads.map((thread) => (
+                                paginatedThreads.map((thread) => (
                                     <CommandItem className='mb-2' key={thread.id}>
                                         <div
                                             className='bg-tertiary hover:bg-quaternary group relative flex w-full cursor-pointer flex-col items-start rounded-md p-4 transition-all duration-200'
@@ -188,20 +231,51 @@ export default function ThreadsPage() {
                                 <div className='border-hard mt-2 flex w-full flex-col items-center justify-center gap-4 rounded-md border border-dashed p-4'>
                                     <div className='flex flex-col items-center gap-0'>
                                         <TypographyMuted className='!mt-0'>
-                                            No threads found
+                                            {RecentPageText.NO_THREADS}
                                         </TypographyMuted>
                                         <TypographyMuted className='!mt-1 text-xs opacity-70'>
-                                            Start a new conversation to create a thread
+                                            {RecentPageText.START_THREAD}
                                         </TypographyMuted>
                                     </div>
-                                    <Button onClick={() => push('/')} size='sm' variant='default'>
+                                    <Button
+                                        onClick={() => push(PublicRoutes.HOME)}
+                                        size='sm'
+                                        variant='default'
+                                    >
                                         <Plus size={14} strokeWidth={2} />
-                                        New Thread
+                                        {RecentPageText.NEW_THREAD}
                                     </Button>
                                 </div>
                             )}
                     </CommandList>
                 </Command>
+                {totalPages > 1 && (
+                    <div className='mt-4 flex w-full items-center justify-between'>
+                        <TypographyMuted className='!mt-0 text-xs'>
+                            {PaginationText.PAGE} {currentPage} {PaginationText.OF} {totalPages}
+                        </TypographyMuted>
+                        <div className='flex gap-2'>
+                            <Button
+                                disabled={currentPage === 1}
+                                onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                                size='icon-sm'
+                                variant='outline'
+                            >
+                                <ChevronLeft size={14} strokeWidth={2} />
+                                <span className='sr-only'>{AriaLabel.PREV_PAGE}</span>
+                            </Button>
+                            <Button
+                                disabled={currentPage === totalPages}
+                                onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                                size='icon-sm'
+                                variant='outline'
+                            >
+                                <ChevronRight size={14} strokeWidth={2} />
+                                <span className='sr-only'>{AriaLabel.NEXT_PAGE}</span>
+                            </Button>
+                        </div>
+                    </div>
+                )}
             </div>
 
             <LoginRequiredDialog

--- a/memory-bank/2025-08-16-recent-page-pagination-entrypoints.md
+++ b/memory-bank/2025-08-16-recent-page-pagination-entrypoints.md
@@ -1,0 +1,5 @@
+# Recent Page Pagination and Entrypoints Link
+
+- Added pagination controls and env-based page size to `/recent` page.
+- Introduced `/entrypoints` page and linked from sidebar and recent page.
+- Centralized routes for entrypoints and recent in shared constants.

--- a/packages/common/components/side-bar.tsx
+++ b/packages/common/components/side-bar.tsx
@@ -5,6 +5,7 @@ import { useAdmin, useCreemSubscription, useLogout } from '@repo/common/hooks';
 import { useAppStore, useChatStore } from '@repo/common/store';
 import { getSessionCacheBustedAvatarUrl } from '@repo/common/utils/avatar-cache';
 import { BUTTON_TEXT, TOOLTIP_TEXT } from '@repo/shared/constants';
+import { PublicRoutes } from '@repo/shared/constants/routes';
 import { useSession } from '@repo/shared/lib/auth-client';
 import { log } from '@repo/shared/logger';
 import type { Thread } from '@repo/shared/types';
@@ -65,6 +66,10 @@ import {
 import { Logo } from './logo';
 import './sidebar.css';
 import { UserTierBadge as SidebarUserTierBadge } from './user-tier-badge';
+
+enum SidebarLinkText {
+    ENTRYPOINTS = 'Entrypoints',
+}
 
 export const Sidebar = ({ forceMobile = false }: { forceMobile?: boolean; } = {}) => {
     const { setIsCommandSearchOpen, setIsMobileSidebarOpen } = useRootContext();
@@ -465,6 +470,18 @@ export const Sidebar = ({ forceMobile = false }: { forceMobile?: boolean; } = {}
                                     >
                                         <FileText size={16} strokeWidth={2} />
                                         AI Resources
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            push(PublicRoutes.ENTRYPOINTS);
+                                            if (forceMobile) {
+                                                setIsMobileSidebarOpen(false);
+                                            }
+                                        }}
+                                    >
+                                        <Terminal size={16} strokeWidth={2} />
+                                        {SidebarLinkText.ENTRYPOINTS}
                                     </DropdownMenuItem>
                                     <DropdownMenuItem
                                         onClick={(e) => {

--- a/packages/shared/constants/routes.ts
+++ b/packages/shared/constants/routes.ts
@@ -15,6 +15,8 @@ export const PublicRoutes = {
     TERMS: '/terms',
     HELP: '/help',
     ABOUT: '/about',
+    ENTRYPOINTS: '/entrypoints',
+    RECENT: '/recent',
 } as const;
 
 export type PublicRoute = (typeof PublicRoutes)[keyof typeof PublicRoutes];


### PR DESCRIPTION
## Summary
- add pagination and design tweaks to /recent history view
- add /entrypoints page and link from sidebar
- centralize recent and entrypoints routes

## Testing
- `bun run fmt`
- `bun run lint` *(fails: eslint-plugin-unicorn/no-empty-file and numerous no-console violations)*
- `bun run build` *(fails: Failed to collect page data for /api/admin/database-metrics)*
- `bun test` *(fails: multiple test failures and unhandled errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bcad1f448323afcc1264bbfa42a1