### PR TITLE
chore: update Gemini 2.5 Flash Lite references

### DIFF
--- a/apps/web/app/tests/error-diagnostic-integration.test.ts
+++ b/apps/web/app/tests/error-diagnostic-integration.test.ts
@@ -16,7 +16,7 @@ describe('Error Diagnostic Integration', () => {
                 { message: 'Network timeout occurred', code: 'NETWORK_ERROR' },
 
                 // Model error
-                'Model gemini-2.5-flash-lite-preview-06-17 is not available',
+                'Model gemini-2.5-flash-lite is not available',
 
                 // Generic object error
                 { status: 500, error: 'Internal server error' },

--- a/apps/web/app/tests/gemini-api-integration.test.ts
+++ b/apps/web/app/tests/gemini-api-integration.test.ts
@@ -25,7 +25,7 @@ vi.mock('@/lib/services/rate-limit', () => mockRateLimit);
 // Mock the model functions
 vi.mock('@repo/ai/models', () => ({
     ModelEnum: {
-        GEMINI_2_5_FLASH_LITE: 'gemini-2.5-flash-lite-preview-06-17',
+        GEMINI_2_5_FLASH_LITE: 'gemini-2.5-flash-lite',
         GPT_4o: 'gpt-4o',
     },
     getModelFromChatMode: vi.fn(),

--- a/apps/web/app/tests/gemini-chart-function-calling.test.ts
+++ b/apps/web/app/tests/gemini-chart-function-calling.test.ts
@@ -11,7 +11,7 @@ describe('GEMINI_2_5_FLASH_LITE Chart Function Calling', () => {
             expect(supportsTools(model)).toBe(true);
 
             // Model enum should be correct
-            expect(model).toBe('gemini-2.5-flash-lite-preview-06-17');
+            expect(model).toBe('gemini-2.5-flash-lite');
         });
 
         it('should have chart tools available and properly configured', () => {
@@ -44,7 +44,7 @@ describe('GEMINI_2_5_FLASH_LITE Chart Function Calling', () => {
                 parentThreadItemId: 'test-parent',
                 prompt: 'Create a chart',
                 messages: [],
-                mode: 'gemini-2.5-flash-lite-preview-06-17',
+                mode: 'gemini-2.5-flash-lite',
                 webSearch: false,
                 mathCalculator: false,
                 charts: true, // This should now be accepted

--- a/apps/web/app/tests/gemini-chart-tools.test.ts
+++ b/apps/web/app/tests/gemini-chart-tools.test.ts
@@ -6,7 +6,7 @@ describe('Gemini Chart Tools Integration', () => {
     describe('GEMINI_2_5_FLASH_LITE Chart Support', () => {
         it('should be marked as supporting charts in models data', () => {
             const testModel = ModelEnum.GEMINI_2_5_FLASH_LITE;
-            expect(testModel).toBe('gemini-2.5-flash-lite-preview-06-17');
+            expect(testModel).toBe('gemini-2.5-flash-lite');
 
             // This model should support charts according to the models.dev API
             // "charts": true is set for this model in the API response

--- a/apps/web/app/tests/gemini-free-no-byok.test.ts
+++ b/apps/web/app/tests/gemini-free-no-byok.test.ts
@@ -48,7 +48,7 @@ describe('Gemini 2.5 Flash Lite Free Model', () => {
         const modelEnum = getModelFromChatMode(ChatMode.GEMINI_2_5_FLASH_LITE);
         const model = models.find((m) => m.id === modelEnum);
         expect(model).toMatchObject({
-            name: 'Gemini 2.5 Flash Lite Preview 06-17',
+            name: 'Gemini 2.5 Flash Lite',
             provider: 'google',
             isFree: true,
             maxTokens: 65_536,

--- a/apps/web/app/tests/gemini-tool-call-error-handling.test.ts
+++ b/apps/web/app/tests/gemini-tool-call-error-handling.test.ts
@@ -11,7 +11,7 @@ describe('Gemini Tool Call Error Handling', () => {
             // 1. if user is using free model (GEMINI_2_5_FLASH_LITE) AND doesn't have GEMINI API KEY
             //    -> use free gemini model API key for them and count as 1 daily free gemini model usage
 
-            expect(testModel).toBe('gemini-2.5-flash-lite-preview-06-17');
+            expect(testModel).toBe('gemini-2.5-flash-lite');
 
             // This should be allowed (use system key, count usage)
             const shouldUseSystemKey = !userHasApiKey
@@ -27,7 +27,7 @@ describe('Gemini Tool Call Error Handling', () => {
             // 2. if user is using free model (GEMINI_2_5_FLASH_LITE) AND has GEMINI API KEY
             //    -> use their gemini api key and DON't count -> remember has BYOK -> unlimited usage
 
-            expect(testModel).toBe('gemini-2.5-flash-lite-preview-06-17');
+            expect(testModel).toBe('gemini-2.5-flash-lite');
 
             // This should use user's key (unlimited usage)
             const shouldUseSystemKey = !userHasApiKey
@@ -74,7 +74,7 @@ describe('Gemini Tool Call Error Handling', () => {
 
         it('should validate model enum consistency', () => {
             // Ensure the model enum value matches what we expect
-            expect(ModelEnum.GEMINI_2_5_FLASH_LITE).toBe('gemini-2.5-flash-lite-preview-06-17');
+            expect(ModelEnum.GEMINI_2_5_FLASH_LITE).toBe('gemini-2.5-flash-lite');
         });
     });
 

--- a/apps/web/app/tests/implementation-check.test.ts
+++ b/apps/web/app/tests/implementation-check.test.ts
@@ -30,12 +30,12 @@ describe('Gemini 2.5 Flash Lite - Implementation Verification', () => {
         const { ModelEnum, models } = await import('@repo/ai/models');
 
         // Check Gemini 2.5 Flash Lite is configured
-        expect(ModelEnum.GEMINI_2_5_FLASH_LITE).toBe('gemini-2.5-flash-lite-preview-06-17');
+        expect(ModelEnum.GEMINI_2_5_FLASH_LITE).toBe('gemini-2.5-flash-lite');
 
         // Find the model in the models array
         const geminiLiteModel = models.find((m) => m.id === ModelEnum.GEMINI_2_5_FLASH_LITE);
         expect(geminiLiteModel).toBeDefined();
-        expect(geminiLiteModel?.name).toBe('Gemini 2.5 Flash Lite Preview 06-17');
+        expect(geminiLiteModel?.name).toBe('Gemini 2.5 Flash Lite');
         expect(geminiLiteModel?.provider).toBe('google');
         expect(geminiLiteModel?.isFree).toBe(true);
     });
@@ -44,7 +44,7 @@ describe('Gemini 2.5 Flash Lite - Implementation Verification', () => {
         const { ChatMode, ChatModeConfig } = await import('@repo/shared/config');
 
         // Check chat mode exists
-        expect(ChatMode.GEMINI_2_5_FLASH_LITE).toBe('gemini-2.5-flash-lite-preview-06-17');
+        expect(ChatMode.GEMINI_2_5_FLASH_LITE).toBe('gemini-2.5-flash-lite');
 
         // Check configuration
         const config = ChatModeConfig[ChatMode.GEMINI_2_5_FLASH_LITE];

--- a/apps/web/app/tests/rate-limit-simple.test.ts
+++ b/apps/web/app/tests/rate-limit-simple.test.ts
@@ -18,7 +18,7 @@ describe('Gemini 2.5 Flash Lite - Basic Validation', () => {
             const { ModelEnum } = await import('@repo/ai/models');
 
             // Verify the model enum exists
-            expect(ModelEnum.GEMINI_2_5_FLASH_LITE).toBe('gemini-2.5-flash-lite-preview-06-17');
+            expect(ModelEnum.GEMINI_2_5_FLASH_LITE).toBe('gemini-2.5-flash-lite');
         });
 
         it('should identify free models correctly', async () => {

--- a/apps/web/docs/playwright-mcp-test-report.md
+++ b/apps/web/docs/playwright-mcp-test-report.md
@@ -106,7 +106,7 @@ This report documents the real-time testing of the VT Chat authentication system
 - ✅ Home page loads successfully for unauthenticated users
 - ✅ Shows "Good evening" greeting
 - ✅ Chat interface is available
-- ✅ Model selector shows "Gemini 2.5 Flash Lite Preview"
+- ✅ Model selector shows "Gemini 2.5 Flash Lite"
 - ✅ Upgrade button visible (Free tier indication)
 - ✅ Footer links present and accessible
 

--- a/apps/web/e2e/vt-plus-web-search.spec.ts
+++ b/apps/web/e2e/vt-plus-web-search.spec.ts
@@ -42,7 +42,7 @@ test.describe('VT+ Web Search Functionality', () => {
                         parentThreadItemId: `vt-plus-parent-${Date.now()}`,
                         prompt: 'test VT+ web search functionality',
                         messages: [{ role: 'user', content: 'test VT+ web search functionality' }],
-                        mode: 'gemini-2.5-flash-lite-preview-06-17',
+                        mode: 'gemini-2.5-flash-lite',
                         webSearch: true,
                         mathCalculator: false,
                         charts: false,
@@ -89,7 +89,7 @@ test.describe('VT+ Web Search Functionality', () => {
         const rateLimitResponse = await page.evaluate(async () => {
             try {
                 const res = await fetch(
-                    '/api/rate-limit/status?model=gemini-2.5-flash-lite-preview-06-17',
+                    '/api/rate-limit/status?model=gemini-2.5-flash-lite',
                     {
                         method: 'POST',
                     },

--- a/apps/web/e2e/web-search-auth.spec.ts
+++ b/apps/web/e2e/web-search-auth.spec.ts
@@ -19,7 +19,7 @@ test.describe('Web Search Authentication', () => {
                             parentThreadItemId: `test-parent-${Date.now()}`,
                             prompt: 'test query with web search',
                             messages: [{ role: 'user', content: 'test query with web search' }],
-                            mode: 'gemini-2.5-flash-lite-preview-06-17',
+                            mode: 'gemini-2.5-flash-lite',
                             webSearch: true,
                             mathCalculator: false,
                             charts: false,
@@ -51,7 +51,7 @@ test.describe('Web Search Authentication', () => {
             // Test various modes with web search
             const testCases = [
                 {
-                    mode: 'gemini-2.5-flash-lite-preview-06-17',
+                    mode: 'gemini-2.5-flash-lite',
                     expectAuth: true,
                 },
                 {

--- a/apps/web/lib/config/pricing.ts
+++ b/apps/web/lib/config/pricing.ts
@@ -57,7 +57,7 @@ export const PRICING_CONFIG = {
                 {
                     name: 'Access to Gemini Models + Enhanced Tools',
                     description:
-                        'Access all Gemini models (Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 2.5 Flash Lite Preview) plus enhanced tools (web search, math calculator, charts) without needing your own API keys.',
+                        'Access all Gemini models (Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 2.5 Flash Lite) plus enhanced tools (web search, math calculator, charts) without needing your own API keys.',
                 },
                 {
                     name: 'Everything in Free Plan (All Premium AI Models Included)',

--- a/apps/web/lib/database/schema.ts
+++ b/apps/web/lib/database/schema.ts
@@ -190,7 +190,7 @@ export const userRateLimits = pgTable(
         userId: text('user_id')
             .notNull()
             .references(() => users.id, { onDelete: 'cascade' }),
-        modelId: text('model_id').notNull(), // e.g., 'gemini-2.5-flash-lite-preview-06-17'
+        modelId: text('model_id').notNull(), // e.g., 'gemini-2.5-flash-lite'
         dailyRequestCount: text('daily_request_count').notNull().default('0'),
         minuteRequestCount: text('minute_request_count').notNull().default('0'),
         lastDailyReset: timestamp('last_daily_reset').notNull().defaultNow(),
@@ -214,7 +214,7 @@ export const providerUsage = pgTable(
         userId: text('user_id')
             .notNull()
             .references(() => users.id, { onDelete: 'cascade' }),
-        modelId: text('model_id').notNull(), // e.g., 'gemini-2.5-flash-lite-preview-06-17' or 'deep-research'
+        modelId: text('model_id').notNull(), // e.g., 'gemini-2.5-flash-lite' or 'deep-research'
         requestTimestamp: timestamp('request_timestamp').notNull().defaultNow(),
         provider: text('provider').notNull().default('gemini'), // 'gemini', 'openai', etc.
         createdAt: timestamp('created_at').notNull().defaultNow(),

--- a/apps/web/lib/services/rate-limit.ts
+++ b/apps/web/lib/services/rate-limit.ts
@@ -381,7 +381,7 @@ export interface RateLimitStatus {
  * Check if user can make a request to the specified model
  * Rate limits are enforced PER USER ACCOUNT
  * VT+ users get enhanced limits
- * VT+ users have unlimited access to gemini-2.5-flash-lite-preview-06-17
+ * VT+ users have unlimited access to gemini-2.5-flash-lite
  * VT+ users using other Gemini models count against both model-specific AND Flash Lite quotas
  */
 export async function checkRateLimit(
@@ -670,7 +670,7 @@ export async function recordRequest(
 
 /**
  * Get current rate limit status for a user and model
- * VT+ users have unlimited access to gemini-2.5-flash-lite-preview-06-17 but usage is tracked for display
+ * VT+ users have unlimited access to gemini-2.5-flash-lite but usage is tracked for display
  * VT+ users using other Gemini models show dual quota status
  */
 export async function getRateLimitStatus(

--- a/docs/DATABASE_SETUP.md
+++ b/docs/DATABASE_SETUP.md
@@ -56,14 +56,14 @@ psql $DATABASE_URL -f apps/web/create-rate-limits-table.sql
 
 After running the migration, you should be able to:
 
-1. **Test the rate limit API**: Visit `/api/rate-limit/status?model=gemini-2.5-flash-lite-preview-06-17`
-2. **See the free model in the dropdown**: The Gemini 2.5 Flash Lite Preview should appear first in the Google models section
+1. **Test the rate limit API**: Visit `/api/rate-limit/status?model=gemini-2.5-flash-lite`
+2. **See the free model in the dropdown**: The Gemini 2.5 Flash Lite should appear first in the Google models section
 3. **No BYOK dialog**: Selecting the free model should not trigger the "Bring Your Own Key" dialog
 
 ## What's Fixed
 
 ✅ **Database table created**: `user_rate_limits` table with proper schema
 ✅ **BYOK dialog fixed**: Free model doesn't require user API key\
-✅ **Default model**: Gemini 2.5 Flash Lite Preview is now the default
+✅ **Default model**: Gemini 2.5 Flash Lite is now the default
 ✅ **Model ordering**: Free model appears first in Google section
 ✅ **Rate limiting**: 10 requests/day per account, 1 request/minute per account

--- a/docs/MANUAL_TESTING_GUIDE.md
+++ b/docs/MANUAL_TESTING_GUIDE.md
@@ -14,7 +14,7 @@ This guide helps you manually test the AI routing fix to ensure all models corre
 
 ### 1. Free Models (Should work without VT+)
 
-- **Model**: Gemini 2.5 Flash Lite Preview
+- **Model**: Gemini 2.5 Flash Lite
 - **Expected**: Routes to `/api/completion` (server-funded)
 - **Test**: Send a simple message like "Hello, test free model"
 

--- a/docs/TESTING_SUMMARY.md
+++ b/docs/TESTING_SUMMARY.md
@@ -42,7 +42,7 @@ The AI routing fix has been successfully implemented and deployed to production 
 
 #### ✅ Should Route to `/api/completion`:
 
-- **Free Models**: Gemini 2.5 Flash Lite Preview
+- **Free Models**: Gemini 2.5 Flash Lite
 - **VT+ Models**: Claude 4 Sonnet, Claude 4 Opus, GPT 4o, GPT 4o Mini, DeepSeek R1, Gemini 2.5 Pro
 - **VT+ Features**: Deep Research, Pro Search
 

--- a/docs/document-upload-feature.md
+++ b/docs/document-upload-feature.md
@@ -16,7 +16,7 @@ The VTChat application now supports document uploads for enhanced AI conversatio
 Document upload is currently **only available for Gemini models**:
 
 - gemini-2.5-flash
-- gemini-2.5-flash-lite-preview-06-17
+- gemini-2.5-flash-lite
 - gemini-2.5-flash-preview-05-20
 - gemini-2.5-pro-preview-05-06
 - gemini-2.5-pro-preview-06-05

--- a/docs/free-models-update.md
+++ b/docs/free-models-update.md
@@ -58,7 +58,7 @@ Enhanced the VT platform's free tier by updating GEMINI_2_5_FLASH_LITE configura
 - **Enhanced "Access to Free Models" benefit** to include all available free models:
   - Gemini 2.5 Pro Preview
   - Gemini 2.5 Flash
-  - Gemini 2.5 Flash Lite Preview
+  - Gemini 2.5 Flash Lite
   - DeepSeek V3
   - DeepSeek R1
   - Qwen3 14B
@@ -115,7 +115,7 @@ Enhanced the VT platform's free tier by updating GEMINI_2_5_FLASH_LITE configura
 ### Google Gemini (Free Tier)
 
 - **Gemini 2.5 Flash** - Fast, efficient model for general tasks
-- **Gemini 2.5 Flash Lite Preview** - Preview access to latest features
+- **Gemini 2.5 Flash Lite** - Access to latest features
 - **Gemini 2.5 Pro Preview** - Preview access to Pro-level capabilities (Note: Gemini 2.5 Pro is premium only)
 
 ### OpenRouter Models (Free Tier)

--- a/docs/guides/gemini-free-model-setup.md
+++ b/docs/guides/gemini-free-model-setup.md
@@ -1,6 +1,6 @@
-# Gemini 2.5 Flash Lite Preview - Free Model Setup
+# Gemini 2.5 Flash Lite - Free Model Setup
 
-This guide covers the implementation of the free Gemini 2.5 Flash Lite Preview model with rate limiting for registered users.
+This guide covers the implementation of the free Gemini 2.5 Flash Lite model with rate limiting for registered users.
 
 ## Overview
 
@@ -228,5 +228,5 @@ Use the rate limit status API for debugging:
 
 ```bash
 curl -H "Authorization: Bearer <token>" \
-  "https://your-app.fly.dev/api/rate-limit/status?model=gemini-2.5-flash-lite-preview-06-17"
+  "https://your-app.fly.dev/api/rate-limit/status?model=gemini-2.5-flash-lite"
 ```

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -755,7 +755,7 @@ CREATE INDEX CONCURRENTLY idx_sessions_token ON sessions(token);
 
 - **Gemini 2.5 Pro** - Pro-level access
 - **Gemini 2.5 Flash** - Fast, efficient general-purpose model
-- **Gemini 2.5 Flash Lite Preview** - Latest preview features
+- **Gemini 2.5 Flash Lite** - Latest features
 
 **OpenRouter Models (Free)**:
 
@@ -942,3 +942,7 @@ CREATE INDEX CONCURRENTLY idx_sessions_token ON sessions(token);
 - **Build Status**: ✅ All changes compile successfully with no breaking changes
 
 **Result**: VT offers free tier, and with VT+ focusing only on 3 exclusive research capabilities: Deep Research, Pro Search.
+
+### 2025-08-22
+
+- Updated Gemini 2.5 Flash Lite references to stable model and ID across codebase and docs.

--- a/memory-bank/tier-system-update.md
+++ b/memory-bank/tier-system-update.md
@@ -10,7 +10,7 @@ Successfully updated VT's tier system to reflect the new feature distribution wh
 
 **Features now available:**
 
-- Free access to Gemini 2.5 Flash Lite Preview (10 requests/day, 1/minute limit)
+- Free access to Gemini 2.5 Flash Lite (10 requests/day, 1/minute limit)
 - Dark Mode interface
 - Structured Output extraction
 - Thinking Mode with reasoning display

--- a/packages/ai/cache/README.md
+++ b/packages/ai/cache/README.md
@@ -5,7 +5,7 @@ This module provides cost-effective caching for Gemini 2.5 and 2.0 models using 
 ## Features
 
 - **Cost Reduction**: Reuse conversation context across multiple queries to reduce API costs
-- **Supported Models**: Gemini 2.5 Pro, Gemini 2.5 Flash and Gemini 2.5 Flash Lite Preview.
+- **Supported Models**: Gemini 2.5 Pro, Gemini 2.5 Flash and Gemini 2.5 Flash Lite.
 - **Configurable TTL**: Set cache duration from 1 minute to 1 hour
 - **Cache Management**: Manage up to 20 cached conversations simultaneously
 - **Authentication Integration**: Seamlessly integrated with VTChat's authentication system

--- a/packages/common/components/chat-input/chat-config.tsx
+++ b/packages/common/components/chat-input/chat-config.tsx
@@ -215,7 +215,7 @@ export const modelOptionsByProvider = {
 
     Google: [
         {
-            label: 'Gemini 2.5 Flash Lite Preview',
+            label: 'Gemini 2.5 Flash Lite',
             value: ChatMode.GEMINI_2_5_FLASH_LITE,
             webSearch: true,
             icon: <Gift className='text-green-500' size={16} />,

--- a/packages/common/components/settings-modal.tsx
+++ b/packages/common/components/settings-modal.tsx
@@ -358,8 +358,8 @@ export const ApiKeySettings = () => {
                                 <div className='text-muted-foreground text-xs md:text-sm'>
                                     <strong>Pro tip:</strong>{' '}
                                     With your own API key, you'll have access to Gemini 2.5 Pro,
-                                    Gemini 2.5 Flash, Gemini 2.5 Flash Lite Preview and other
-                                    premium models without restrictions
+                                    Gemini 2.5 Flash, Gemini 2.5 Flash Lite and other premium models
+                                    without restrictions
                                     {isVtPlus
                                         ? ', plus you already enjoy enhanced limits (5x daily, 2x per-minute) with VT+'
                                         : ''}

--- a/packages/common/tests/critical-api-key-leak-fix.test.ts
+++ b/packages/common/tests/critical-api-key-leak-fix.test.ts
@@ -16,7 +16,7 @@ describe('CRITICAL API Key Leak Fix', () => {
 
     it('CRITICAL: should remove ALL provider API keys for server-funded Gemini models', () => {
         // Test the exact scenario from the bug report
-        const mode = ChatMode.GEMINI_2_5_FLASH_LITE; // "gemini-2.5-flash-lite-preview-06-17"
+        const mode = ChatMode.GEMINI_2_5_FLASH_LITE; // "gemini-2.5-flash-lite"
         const isServerFunded = true; // VT+ user with server-funded model
 
         const result = filterApiKeysForServerSide(mockApiKeys, mode, isServerFunded);

--- a/packages/shared/config/payment.ts
+++ b/packages/shared/config/payment.ts
@@ -89,7 +89,7 @@ export const VT_BASE_PRODUCT_INFO = {
     name: 'VT Base',
     slug: PlanSlug.VT_BASE,
     features: [
-        'Free access to Gemini 2.5 Flash Lite Preview (10 requests/day)',
+        'Free access to Gemini 2.5 Flash Lite (10 requests/day)',
         'Dark Mode interface',
         'Structured Output extraction',
         'Thinking Mode with reasoning display',

--- a/packages/shared/config/vt-plus-features.ts
+++ b/packages/shared/config/vt-plus-features.ts
@@ -37,7 +37,7 @@ export const VT_PLUS_FEATURES: Partial<Record<FeatureSlug, VTPlusFeature>> = {
         id: FeatureSlug.GEMINI_MODELS_NO_BYOK,
         name: 'All Gemini Models Without BYOK',
         description:
-            'Access all Gemini models (Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 2.5 Flash Lite Preview) plus enhanced tools (web search, math calculator, charts) without needing your own API keys.',
+            'Access all Gemini models (Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 2.5 Flash Lite) plus enhanced tools (web search, math calculator, charts) without needing your own API keys.',
         enabled: true,
     },
 } as const;

--- a/packages/shared/constants/rate-limits.ts
+++ b/packages/shared/constants/rate-limits.ts
@@ -38,7 +38,7 @@ export const GEMINI_PRICES = {
     FLASH_LITE: 0.005, // 0.5 cents per request - minimum to ensure non-zero cost tracking
     FLASH: 0.01, // 1 cent per request
     PRO: 0.015, // 1.5 cents per request
-    'gemini-2.5-flash-lite-preview-06-17': 0.005, // Same as FLASH_LITE
+    'gemini-2.5-flash-lite': 0.005, // Same as FLASH_LITE
 } as const;
 
 /**

--- a/packages/shared/types/subscription.ts
+++ b/packages/shared/types/subscription.ts
@@ -235,7 +235,7 @@ export const FEATURES: Record<FeatureSlug, FeatureConfig> = {
         slug: FeatureSlug.GEMINI_MODELS_NO_BYOK,
         name: 'All Gemini Models Without BYOK',
         description:
-            'Access all Gemini models (Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 2.5 Flash Lite Preview) plus enhanced tools (web search, math calculator, charts) without needing your own API keys',
+            'Access all Gemini models (Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 2.5 Flash Lite) plus enhanced tools (web search, math calculator, charts) without needing your own API keys',
     },
 };
 

--- a/scripts/test-server-web-search.js
+++ b/scripts/test-server-web-search.js
@@ -11,7 +11,7 @@ async function testServerWebSearch() {
     console.log('\n📋 Testing web search via server request');
 
     const requestBody = {
-        mode: 'gemini-2.5-flash-lite-preview-06-17',
+        mode: 'gemini-2.5-flash-lite',
         prompt: 'who is vinhnx',
         threadId: 'test-thread-' + Date.now(),
         messages: [{ role: 'user', content: 'who is vinhnx?' }],

--- a/scripts/test-unified-web-search.js
+++ b/scripts/test-unified-web-search.js
@@ -137,7 +137,7 @@ async function testSearchCapabilityDifferentiation() {
 
     try {
         // Test that the gemini-web-search task can differentiate between modes
-        const basicMode = 'gemini-2.5-flash-lite-preview-06-17';
+        const basicMode = 'gemini-2.5-flash-lite';
         const proMode = 'pro';
 
         console.log(`  - Basic mode: ${basicMode}`);

--- a/scripts/test-web-search-flow.js
+++ b/scripts/test-web-search-flow.js
@@ -14,7 +14,7 @@ async function testWebSearchFlow() {
     log.info('\n📋 Testing web search flow with curl-like request');
 
     const requestBody = {
-        mode: 'gemini-2.5-flash-lite-preview-06-17',
+        mode: 'gemini-2.5-flash-lite',
         prompt: 'who is vinhnx',
         threadId: 'test-thread-id',
         messages: [
@@ -131,7 +131,7 @@ async function testWebSearchFlowWithApiKey() {
     log.info('\n📋 Testing web search flow with user API key');
 
     const requestBody = {
-        mode: 'gemini-2.5-flash-lite-preview-06-17',
+        mode: 'gemini-2.5-flash-lite',
         prompt: 'who is vinhnx',
         threadId: 'test-thread-id-2',
         messages: [

--- a/scripts/test-web-search-with-api-key.js
+++ b/scripts/test-web-search-with-api-key.js
@@ -11,7 +11,7 @@ async function testWebSearchWithServerKey() {
     console.log('\n📋 Testing web search with server-funded API key');
 
     const requestBody = {
-        mode: 'gemini-2.5-flash-lite-preview-06-17',
+        mode: 'gemini-2.5-flash-lite',
         prompt: 'who is vinhnx',
         threadId: 'test-thread-' + Date.now(),
         messages: [{ role: 'user', content: 'who is vinhnx?' }],


### PR DESCRIPTION
## Summary
- replace Gemini 2.5 Flash Lite Preview with Gemini 2.5 Flash Lite
- replace gemini-2.5-flash-lite-preview-06-17 model ID with gemini-2.5-flash-lite
- update memory bank entry for final Gemini 2.5 Flash Lite release

## Testing
- `bunx dprint@latest fmt`
- `bunx prettier@latest --write "**/*.md"` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `bunx oxlint@latest`
- `bun test` *(fails: Cannot find module '@playwright/test')*


------
https://chatgpt.com/codex/tasks/task_e_68a85914858c8323bdd528d7523f2dc5