### PR TITLE
feat(web): add firsto badges to about page

### DIFF
--- a/apps/web/components/badges/badges-section.tsx
+++ b/apps/web/components/badges/badges-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { AiToolsBadge } from './aitools-badge';
+import { FirstoBadges } from './firsto-badges';
 import { GoodFirmsBadge } from './goodfirms-badge';
 
 interface BadgesSectionProps {
@@ -22,6 +23,11 @@ export function BadgesSection({ className }: BadgesSectionProps) {
                 {/* GoodFirms Badge */}
                 <div className='badge-item flex-shrink-0'>
                     <GoodFirmsBadge className='transition-transform duration-200 hover:scale-105 focus:scale-105' />
+                </div>
+
+                {/* Firsto Badges */}
+                <div className='badge-item flex-shrink-0'>
+                    <FirstoBadges />
                 </div>
             </div>
 

--- a/apps/web/components/badges/firsto-badges.tsx
+++ b/apps/web/components/badges/firsto-badges.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import Image from 'next/image';
+import { useState } from 'react';
+
+const BADGE_WIDTH = 195;
+const BADGE_HEIGHT = 49;
+
+const enum FirstoBadgeUrls {
+    PROJECT = 'https://firsto.co/projects/vt-chat',
+    DAILY = 'https://firsto.co/images/badges/daily-top1.svg',
+    WEEKLY = 'https://firsto.co/images/badges/weekly-top3.svg',
+}
+
+const enum FirstoBadgeAlt {
+    DAILY = 'Firsto Top 1 Daily Winner',
+    WEEKLY = 'Firsto Top 3 Weekly Winner',
+}
+
+interface FirstoBadgesProps {
+    className?: string;
+}
+
+function FirstoBadgeItem(
+    { src, alt, className }: { src: string; alt: string; className?: string; },
+) {
+    const [hasError, setHasError] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
+
+    if (hasError) {
+        return null;
+    }
+
+    return (
+        <a
+            href={FirstoBadgeUrls.PROJECT}
+            target='_blank'
+            rel='noopener noreferrer'
+            className={`${className} block`}
+            style={{ width: `${BADGE_WIDTH}px`, height: 'auto' }}
+            aria-label={alt}
+        >
+            <div className='relative'>
+                {isLoading && (
+                    <div
+                        className='absolute inset-0 animate-pulse rounded bg-gray-200 dark:bg-gray-700'
+                        style={{ width: `${BADGE_WIDTH}px`, height: `${BADGE_HEIGHT}px` }}
+                    />
+                )}
+                <Image
+                    src={src}
+                    alt={alt}
+                    width={BADGE_WIDTH}
+                    height={BADGE_HEIGHT}
+                    style={{ width: `${BADGE_WIDTH}px`, height: 'auto', objectFit: 'contain' }}
+                    onError={() => setHasError(true)}
+                    onLoad={() => setIsLoading(false)}
+                    loading='lazy'
+                    unoptimized
+                />
+            </div>
+        </a>
+    );
+}
+
+export function FirstoBadges({ className }: FirstoBadgesProps) {
+    return (
+        <div className={`flex flex-col items-center gap-4 sm:flex-row ${className || ''}`}>
+            <FirstoBadgeItem
+                src={FirstoBadgeUrls.DAILY}
+                alt={FirstoBadgeAlt.DAILY}
+                className='transition-transform duration-200 hover:scale-105 focus:scale-105'
+            />
+            <FirstoBadgeItem
+                src={FirstoBadgeUrls.WEEKLY}
+                alt={FirstoBadgeAlt.WEEKLY}
+                className='transition-transform duration-200 hover:scale-105 focus:scale-105'
+            />
+        </div>
+    );
+}

--- a/apps/web/components/badges/index.ts
+++ b/apps/web/components/badges/index.ts
@@ -1,3 +1,4 @@
 export { AiToolsBadge } from './aitools-badge';
 export { BadgesSection } from './badges-section';
+export { FirstoBadges } from './firsto-badges';
 export { GoodFirmsBadge } from './goodfirms-badge';

--- a/memory-bank/2025-08-24-firsto-badges-about-page.md
+++ b/memory-bank/2025-08-24-firsto-badges-about-page.md
@@ -1,0 +1,11 @@
+# Firsto Badges Added to About Page - August 24, 2025
+
+## Summary
+
+Integrated Firsto award badges (Daily Top 1 and Weekly Top 3) into the About page's badge section.
+
+## Key Changes Made
+
+- Added `FirstoBadges` component rendering two Firsto award badges.
+- Updated `BadgesSection` to include the Firsto badges alongside existing recognitions.
+- Exported the new badges component for reuse.


### PR DESCRIPTION
## Summary
- add Firsto award badges component
- show Firsto badges in About page badge section
- document Firsto badge addition in memory bank

## Testing
- `bunx dprint fmt apps/web/components/badges/badges-section.tsx apps/web/components/badges/index.ts apps/web/components/badges/firsto-badges.tsx memory-bank/2025-08-24-firsto-badges-about-page.md`
- `bun run format`
- `bun run lint` (fails: 906 warnings, 121 errors)
- `bun run lint:type-aware` (fails: 906 warnings, 121 errors)
- `bun test` (fails: Playwright suite errors, failing unit tests)


------
https://chatgpt.com/codex/tasks/task_e_68aad753f77c83238a7bd5f096942736