### PR TITLE
docs: record fly deployment cancellation attempt

### DIFF
--- a/memory-bank/2025-08-24-fly-deployment-cancellation.md
+++ b/memory-bank/2025-08-24-fly-deployment-cancellation.md
@@ -1,0 +1,7 @@
+# Fly Deployment Cancellation Attempt
+
+- **Date**: 2025-08-24
+- **Summary**: Attempted to check and cancel Fly.io deployments for `vtchat`.
+- **Outcome**: Unable to authenticate with Fly.io; no access token provided. No deployments were modified.
+- **Next Steps**: Acquire a valid `FLY_API_TOKEN` and rerun `flyctl status -a vtchat` and `flyctl releases`
+  to inspect deployments before cancellation.


### PR DESCRIPTION
## Summary
- document failed attempt to inspect or cancel Fly.io deployments due to missing `FLY_API_TOKEN`

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aad998aec88323b2ec61305f9aac0a