### PR TITLE
feat: add Claude Sonnet 4.5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ _Advanced AI capabilities including document processing, web search, and structu
 ### Advanced AI Capabilities
 
 - **Nano Banana Conversational Image Editor (New to VT)**: Conversational image editor! Generate an image, then iteratively edit through natural conversation: "make the cat bigger", "change background to sunset", "add a party hat" - all while preserving edit history
-- **Premium AI Models (Free with BYOK)**: Claude 4 Sonnet/Opus, GPT-4.1, O3/O3 Mini/O4 Mini, O1 Mini/Preview, Gemini 2.5 Pro, DeepSeek R1, Grok 3 - all available to logged-in users with their own API keys
+- **Premium AI Models (Free with BYOK)**: Claude Sonnet 4.5, Claude 4 Sonnet/Opus, GPT-4.1, O3/O3 Mini/O4 Mini, O1 Mini/Preview, Gemini 2.5 Pro, DeepSeek R1, Grok 3 - all available to logged-in users with their own API keys
 - **9 Free Server Models**: Gemini 2.0/2.5 Flash series + OpenRouter models (DeepSeek V3, Qwen3 14B) - no API keys required
 - **Free Local AI**: Run AI models on your own computer with **Ollama** and **LM Studio** - completely free, private, and no API costs
 - **Multi-AI Provider Support**: OpenAI, Anthropic, Google, Fireworks, Together AI, xAI, plus local providers (Ollama, LM Studio)

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -15,7 +15,7 @@ VT is a production-ready, privacy-focused AI chat application delivering cutting
 ### Key Features
 
 **Advanced AI Capabilities:**
-- **Premium AI Models (Free with BYOK)**: Claude 4 Sonnet/Opus, GPT-4.1, O3/O3 Mini/O4 Mini, O1 Mini/Preview, Gemini 2.5 Pro, DeepSeek R1, Grok 3 - all available to logged-in users with their own API keys
+- **Premium AI Models (Free with BYOK)**: Claude Sonnet 4.5, Claude 4 Sonnet/Opus, GPT-4.1, O3/O3 Mini/O4 Mini, O1 Mini/Preview, Gemini 2.5 Pro, DeepSeek R1, Grok 3 - all available to logged-in users with their own API keys
 - **9 Free AI Models**: Gemini 2.0/2.5 Flash series + OpenRouter models (DeepSeek V3, Qwen3 14B)
 - **Multi-AI Provider Support**: OpenAI, Anthropic, Google, Fireworks, Together AI, and xAI integration
 - **Intelligent Tool Router (Free)**: AI-powered semantic routing automatically activates the right tools based on your queries using OpenAI embeddings and pattern matching

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -15,7 +15,7 @@ VT is a production-ready, privacy-focused AI chat application with security and 
 
 ### Advanced AI Capabilities
 
-- **Premium AI Models (VT+ Exclusive)**: Claude 4 Sonnet/Opus, GPT-4.1, O3/O3 Mini/O4 Mini, O1 Mini/Preview, Gemini 2.5 Pro, DeepSeek R1, Grok 3
+- **Premium AI Models (VT+ Exclusive)**: Claude Sonnet 4.5, Claude 4 Sonnet/Opus, GPT-4.1, O3/O3 Mini/O4 Mini, O1 Mini/Preview, Gemini 2.5 Pro, DeepSeek R1, Grok 3
 - **Thinking Mode (Free)**: Complete AI SDK reasoning tokens support with transparent thinking process across Gemini 2.5, DeepSeek R1, Claude 4, and OpenAI o-series models - available to all logged-in users
 - **Structured Output Extraction (Free)**: AI-powered JSON data extraction from documents with intelligent schema generation - available to all logged-in users
 - **Multi-Modal Processing (Free)**: Text, image, and document analysis with up to 10MB file support - available to all logged-in users

--- a/docs/MANUAL_TESTING_GUIDE.md
+++ b/docs/MANUAL_TESTING_GUIDE.md
@@ -24,6 +24,7 @@ Test these models should all route to `/api/completion`:
 
 #### Anthropic Models
 
+- **Claude Sonnet 4.5** ✅
 - **Claude 4 Sonnet** ✅
 - **Claude 4 Opus** ✅
 

--- a/docs/TESTING_SUMMARY.md
+++ b/docs/TESTING_SUMMARY.md
@@ -43,7 +43,7 @@ The AI routing fix has been successfully implemented and deployed to production 
 #### ✅ Should Route to `/api/completion`:
 
 - **Free Models**: Gemini 2.5 Flash Lite Preview
-- **VT+ Models**: Claude 4 Sonnet, Claude 4 Opus, GPT 4o, GPT 4o Mini, DeepSeek R1, Gemini 2.5 Pro
+- **VT+ Models**: Claude Sonnet 4.5, Claude 4 Sonnet, Claude 4 Opus, GPT 4o, GPT 4o Mini, DeepSeek R1, Gemini 2.5 Pro
 - **VT+ Features**: Deep Research, Pro Search
 
 #### Expected Network Requests:
@@ -79,6 +79,7 @@ bun test packages/common/tests/ai-routing.test.ts
 
 - [ ] Login to vtchat.io.vn successfully
 - [ ] Open DevTools Network tab
+- [ ] Test Claude Sonnet 4.5 → verify `/api/completion` call
 - [ ] Test Claude 4 Sonnet → verify `/api/completion` call
 - [ ] Test Claude 4 Opus → verify `/api/completion` call
 - [ ] Test GPT 4o → verify `/api/completion` call

--- a/docs/chat-ui-improvements-status.md
+++ b/docs/chat-ui-improvements-status.md
@@ -17,7 +17,7 @@ The "Generated with" label in thread messages already includes provider names. T
 
 - "Generated with OpenAI GPT 4o"
 - "Generated with OpenRouter DeepSeek V3 0324"
-- "Generated with Anthropic Claude 4 Sonnet"
+- "Generated with Anthropic Claude Sonnet 4.5"
 - "Generated with xAI Grok 3"
 
 ## 2. ✅ Gift Icon for Free Models

--- a/docs/premium-models-free-access-implementation.md
+++ b/docs/premium-models-free-access-implementation.md
@@ -65,7 +65,7 @@
 
 ### Premium Models Confirmed Free:
 
-- Claude 4 Sonnet/Opus
+- Claude Sonnet 4.5 / Claude 4 Sonnet/Opus
 - GPT-4.1/4.1 Mini/4.1 Nano
 - O3/O3 Mini/O4 Mini
 - O1 Mini/O1 Preview

--- a/docs/reasoning-mode-implementation.md
+++ b/docs/reasoning-mode-implementation.md
@@ -77,6 +77,7 @@ export const supportsReasoning = (model: ModelEnum): boolean => {
         ModelEnum.Deepseek_R1,
         ModelEnum.DEEPSEEK_R1,
         // Anthropic Claude 4
+        ModelEnum.CLAUDE_SONNET_4_5,
         ModelEnum.CLAUDE_4_SONNET,
         ModelEnum.CLAUDE_4_OPUS,
         // OpenAI o-series (future)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15,7 +15,7 @@ VT is a production-ready, privacy-focused AI chat application delivering cutting
 ### Key Features
 
 **Advanced AI Capabilities:**
-- **Premium AI Models (Free with BYOK)**: Claude 4 Sonnet/Opus, GPT-4.1, O3/O3 Mini/O4 Mini, O1 Mini/Preview, Gemini 2.5 Pro, DeepSeek R1, Grok 3 - all available to logged-in users with their own API keys
+- **Premium AI Models (Free with BYOK)**: Claude Sonnet 4.5, Claude 4 Sonnet/Opus, GPT-4.1, O3/O3 Mini/O4 Mini, O1 Mini/Preview, Gemini 2.5 Pro, DeepSeek R1, Grok 3 - all available to logged-in users with their own API keys
 - **9 Free AI Models**: Gemini 2.0/2.5 Flash series + OpenRouter models (DeepSeek V3, Qwen3 14B)
 - **Multi-AI Provider Support**: OpenAI, Anthropic, Google, Fireworks, Together AI, and xAI integration
 - **Intelligent Tool Router (Free)**: AI-powered semantic routing automatically activates the right tools based on your queries using OpenAI embeddings and pattern matching

--- a/memory-bank/comprehensive-tier-system-update.md
+++ b/memory-bank/comprehensive-tier-system-update.md
@@ -32,7 +32,7 @@ VT offers free tier, and with VT+ focusing only on 2 exclusive research capabili
 
 - PRO_SEARCH (Enhanced Web Search)
 - DEEP_RESEARCH (Deep Research capabilities)
-- Premium AI Models: Claude 4 Sonnet/Opus, GPT-4.1, O3/O3 Mini/O4 Mini, O1 Mini/Preview, Gemini 2.5 Pro, DeepSeek R1, Grok 3
+- Premium AI Models: Claude Sonnet 4.5, Claude 4 Sonnet/Opus, GPT-4.1, O3/O3 Mini/O4 Mini, O1 Mini/Preview, Gemini 2.5 Pro, DeepSeek R1, Grok 3
 
 ## Files Updated
 

--- a/memory-bank/productContext.md
+++ b/memory-bank/productContext.md
@@ -46,7 +46,7 @@ Available to all logged-in users:
 - Chart Visualization
 - Gemini Explicit Caching
 - Mathematical calculation tools
-- All AI models including ALL premium models: Claude 4 Sonnet/Opus, GPT-4.1, O3/O3 Mini/O4 Mini, O1 Mini/Preview, Gemini 2.5 Pro, DeepSeek R1, Grok 3 (free with BYOK)
+- All AI models including ALL premium models: Claude Sonnet 4.5, Claude 4 Sonnet/Opus, GPT-4.1, O3/O3 Mini/O4 Mini, O1 Mini/Preview, Gemini 2.5 Pro, DeepSeek R1, Grok 3 (free with BYOK)
 - 9 free models with server API (5 Gemini + 4 OpenRouter)
 - Unlimited usage with BYOK
 

--- a/packages/ai/models.ts
+++ b/packages/ai/models.ts
@@ -6,6 +6,7 @@ import type { ProviderEnumType } from './providers';
 export const ModelEnum = {
     CLAUDE_4_1_OPUS: 'claude-opus-4-1-20250805',
     CLAUDE_4_SONNET: 'claude-sonnet-4-20250514',
+    CLAUDE_SONNET_4_5: 'claude-sonnet-4-5',
     CLAUDE_4_OPUS: 'claude-opus-4-20250514',
     GEMINI_2_5_FLASH_LITE: 'gemini-flash-lite-latest',
     GEMINI_2_5_FLASH: 'gemini-flash-latest',
@@ -139,6 +140,13 @@ export const models: Model[] = [
     {
         id: ModelEnum.CLAUDE_4_SONNET,
         name: 'Claude 4 Sonnet',
+        provider: 'anthropic',
+        maxTokens: 64_000,
+        contextWindow: 200_000,
+    },
+    {
+        id: ModelEnum.CLAUDE_SONNET_4_5,
+        name: 'Claude Sonnet 4.5',
         provider: 'anthropic',
         maxTokens: 64_000,
         contextWindow: 200_000,
@@ -303,6 +311,8 @@ export const getModelFromChatMode = (mode?: string): ModelEnum => {
             return ModelEnum.CLAUDE_4_1_OPUS;
         case ChatMode.CLAUDE_4_SONNET:
             return ModelEnum.CLAUDE_4_SONNET;
+        case ChatMode.CLAUDE_SONNET_4_5:
+            return ModelEnum.CLAUDE_SONNET_4_5;
         case ChatMode.CLAUDE_4_OPUS:
             return ModelEnum.CLAUDE_4_OPUS;
         case ChatMode.GPT_4o_Mini:
@@ -366,6 +376,7 @@ export const getChatModeMaxTokens = (mode: ChatMode) => {
         case ChatMode.CLAUDE_4_1_OPUS:
         case ChatMode.CLAUDE_4_SONNET:
         case ChatMode.CLAUDE_4_OPUS:
+        case ChatMode.CLAUDE_SONNET_4_5:
             return 200_000;
         case ChatMode.O3:
         case ChatMode.O3_Mini:
@@ -529,6 +540,7 @@ export const supportsReasoning = (model: ModelEnum): boolean => {
     const anthropicReasoningModels = [
         ModelEnum.CLAUDE_4_1_OPUS, // claude-4.1-opus-20250805
         ModelEnum.CLAUDE_4_SONNET, // claude-4-sonnet-20250514
+        ModelEnum.CLAUDE_SONNET_4_5, // claude-sonnet-4-5
         ModelEnum.CLAUDE_4_OPUS, // claude-4-opus-20250514
     ];
 
@@ -577,6 +589,7 @@ export const supportsTools = (model: ModelEnum): boolean => {
     const anthropicToolModels = [
         ModelEnum.CLAUDE_4_1_OPUS,
         ModelEnum.CLAUDE_4_SONNET,
+        ModelEnum.CLAUDE_SONNET_4_5,
         ModelEnum.CLAUDE_4_OPUS,
     ];
 
@@ -651,6 +664,7 @@ export const getReasoningType = (model: ModelEnum): ReasoningType => {
     const anthropicReasoningModels = [
         ModelEnum.CLAUDE_4_1_OPUS,
         ModelEnum.CLAUDE_4_SONNET,
+        ModelEnum.CLAUDE_SONNET_4_5,
         ModelEnum.CLAUDE_4_OPUS,
     ];
 

--- a/packages/ai/workflow/utils.ts
+++ b/packages/ai/workflow/utils.ts
@@ -1599,6 +1599,7 @@ export const selectAvailableModel = (
             // Anthropic models
             [ModelEnum.CLAUDE_4_1_OPUS]: 'ANTHROPIC_API_KEY',
             [ModelEnum.CLAUDE_4_SONNET]: 'ANTHROPIC_API_KEY',
+            [ModelEnum.CLAUDE_SONNET_4_5]: 'ANTHROPIC_API_KEY',
             [ModelEnum.CLAUDE_4_OPUS]: 'ANTHROPIC_API_KEY',
             // Fireworks models
             [ModelEnum.DEEPSEEK_R1_FIREWORKS]: 'FIREWORKS_API_KEY',
@@ -1639,7 +1640,8 @@ export const selectAvailableModel = (
         ModelEnum.GPT_5, // GPT-5 as top priority for OpenAI models
         ModelEnum.GPT_4o, // More expensive but reliable
         ModelEnum.GPT_4o_Mini, // Most cost-effective OpenAI model
-        ModelEnum.CLAUDE_4_SONNET, // Anthropic fallback
+        ModelEnum.CLAUDE_SONNET_4_5, // Anthropic fallback
+        ModelEnum.CLAUDE_4_SONNET, // Legacy Anthropic fallback
     ];
 
     for (const model of fallbackModels) {

--- a/packages/common/components/api-key-prompt-modal.tsx
+++ b/packages/common/components/api-key-prompt-modal.tsx
@@ -39,6 +39,7 @@ const getRequiredApiKeyForMode = (chatMode: ChatMode): keyof ApiKeys | null => {
         case ChatMode.GEMINI_2_5_FLASH:
         case ChatMode.GEMINI_2_5_PRO:
             return 'GEMINI_API_KEY';
+        case ChatMode.CLAUDE_SONNET_4_5:
         case ChatMode.CLAUDE_4_SONNET:
         case ChatMode.CLAUDE_4_OPUS:
             return 'ANTHROPIC_API_KEY';

--- a/packages/common/components/byok-validation-dialog.tsx
+++ b/packages/common/components/byok-validation-dialog.tsx
@@ -41,6 +41,7 @@ const CHAT_MODE_TO_API_KEY: ProviderKeyMapping = {
     // Anthropic models
     [ChatMode.CLAUDE_4_1_OPUS]: 'ANTHROPIC_API_KEY',
     [ChatMode.CLAUDE_4_SONNET]: 'ANTHROPIC_API_KEY',
+    [ChatMode.CLAUDE_SONNET_4_5]: 'ANTHROPIC_API_KEY',
     [ChatMode.CLAUDE_4_OPUS]: 'ANTHROPIC_API_KEY',
     // Fireworks models
     [ChatMode.DEEPSEEK_R1_FIREWORKS]: 'FIREWORKS_API_KEY',

--- a/packages/common/components/chat-input/chat-config.tsx
+++ b/packages/common/components/chat-input/chat-config.tsx
@@ -32,6 +32,7 @@ export const getChatModeFromModel = (model: Model): ChatMode | null => {
         // Anthropic models
         'Claude 4.1 Opus': ChatMode.CLAUDE_4_1_OPUS,
         'Claude 4 Sonnet': ChatMode.CLAUDE_4_SONNET,
+        'Claude Sonnet 4.5': ChatMode.CLAUDE_SONNET_4_5,
         'Claude 4 Opus': ChatMode.CLAUDE_4_OPUS,
         // OpenAI models
         'GPT-4o': ChatMode.GPT_4o,
@@ -55,6 +56,7 @@ export const getChatModeFromModel = (model: Model): ChatMode | null => {
     const modelIdToChatModeMap: Record<string, ChatMode> = {
         'deepseek/deepseek-chat-v3-0324': ChatMode.DEEPSEEK_V3_0324,
         'deepseek/deepseek-r1': ChatMode.DEEPSEEK_R1,
+        'claude-sonnet-4-5': ChatMode.CLAUDE_SONNET_4_5,
         'qwen/qwen3-235b-a22b': ChatMode.QWEN3_235B_A22B,
         'qwen/qwen3-32b': ChatMode.QWEN3_32B,
         'mistralai/mistral-nemo': ChatMode.MISTRAL_NEMO,
@@ -89,6 +91,7 @@ export const hasReasoningCapability = (chatMode: ChatMode): boolean => {
         // Anthropic reasoning models
         ChatMode.CLAUDE_4_1_OPUS,
         ChatMode.CLAUDE_4_SONNET,
+        ChatMode.CLAUDE_SONNET_4_5,
         ChatMode.CLAUDE_4_OPUS,
 
         // Gemini models with thinking support
@@ -190,6 +193,14 @@ export const modelOptionsByProvider = {
         {
             label: 'Claude 4.1 Opus',
             value: ChatMode.CLAUDE_4_1_OPUS,
+            webSearch: true,
+            icon: <Brain className='text-purple-500' size={16} />,
+            providerIcon: getProviderIcon('anthropic', 14),
+            requiredApiKey: 'ANTHROPIC_API_KEY' as keyof ApiKeys,
+        },
+        {
+            label: 'Claude Sonnet 4.5',
+            value: ChatMode.CLAUDE_SONNET_4_5,
             webSearch: true,
             icon: <Brain className='text-purple-500' size={16} />,
             providerIcon: getProviderIcon('anthropic', 14),

--- a/packages/common/components/reasoning-mode-settings.tsx
+++ b/packages/common/components/reasoning-mode-settings.tsx
@@ -36,6 +36,7 @@ export const ReasoningModeSettings = () => {
             ChatMode.DEEPSEEK_R1,
             // Anthropic reasoning models
             ChatMode.CLAUDE_4_SONNET,
+            ChatMode.CLAUDE_SONNET_4_5,
             ChatMode.CLAUDE_4_OPUS,
             // OpenAI o-series models
             ChatMode.O4_Mini,

--- a/packages/common/hooks/agent-provider.tsx
+++ b/packages/common/hooks/agent-provider.tsx
@@ -964,7 +964,8 @@ export const AgentProvider = ({ children }: { children: ReactNode; }) => {
                 isFreeModel: mode === ChatMode.GEMINI_2_5_FLASH_LITE,
                 hasVtPlusAccess,
                 needsServerSide: (hasVtPlusAccess
-                    && [ChatMode.CLAUDE_4_SONNET, ChatMode.GPT_4o].includes(mode))
+                    && [ChatMode.CLAUDE_4_SONNET, ChatMode.CLAUDE_SONNET_4_5, ChatMode.GPT_4o]
+                        .includes(mode))
                     || isGeminiModel(mode),
                 shouldUseServerSideAPI,
                 hasApiKey: hasApiKeyForChatMode(mode, isSignedIn, hasVtPlusAccess),

--- a/packages/common/lib/ai-routing.ts
+++ b/packages/common/lib/ai-routing.ts
@@ -6,8 +6,6 @@ const FREE_SERVER_MODELS: ChatMode[] = [];
 const PLUS_SERVER_MODELS: ChatMode[] = [
     ChatMode.GEMINI_2_5_PRO,
     ChatMode.GEMINI_2_5_FLASH,
-    ChatMode.CLAUDE_4_SONNET,
-    ChatMode.CLAUDE_SONNET_4_5,
     // Other premium models (OpenAI, xAI, etc.) require BYOK even for VT+ users
 ];
 

--- a/packages/common/lib/ai-routing.ts
+++ b/packages/common/lib/ai-routing.ts
@@ -6,7 +6,9 @@ const FREE_SERVER_MODELS: ChatMode[] = [];
 const PLUS_SERVER_MODELS: ChatMode[] = [
     ChatMode.GEMINI_2_5_PRO,
     ChatMode.GEMINI_2_5_FLASH,
-    // All other models (Claude, OpenAI, xAI, etc.) require BYOK even for VT+ users
+    ChatMode.CLAUDE_4_SONNET,
+    ChatMode.CLAUDE_SONNET_4_5,
+    // Other premium models (OpenAI, xAI, etc.) require BYOK even for VT+ users
 ];
 
 export type ServerSideAPIOpts = {

--- a/packages/common/lib/chat-mode-utils.ts
+++ b/packages/common/lib/chat-mode-utils.ts
@@ -23,6 +23,7 @@ export function isPremiumMode(mode: ChatMode): boolean {
         ChatMode.O3_Mini,
         ChatMode.O4_Mini,
         ChatMode.CLAUDE_4_SONNET,
+        ChatMode.CLAUDE_SONNET_4_5,
         ChatMode.CLAUDE_4_OPUS,
         ChatMode.GEMINI_2_5_PRO,
         ChatMode.GEMINI_2_5_FLASH,

--- a/packages/common/store/api-keys.store.ts
+++ b/packages/common/store/api-keys.store.ts
@@ -249,6 +249,7 @@ export const useApiKeysStore = create<ApiKeysState>()(
                         return true; // Free model, no API key required
                     case ChatMode.CLAUDE_4_1_OPUS:
                     case ChatMode.CLAUDE_4_SONNET:
+                    case ChatMode.CLAUDE_SONNET_4_5:
                     case ChatMode.CLAUDE_4_OPUS:
                         return isValidKey(apiKeys.ANTHROPIC_API_KEY);
                     case ChatMode.DEEPSEEK_R1_FIREWORKS:

--- a/packages/common/tests/ai-routing-security.test.ts
+++ b/packages/common/tests/ai-routing-security.test.ts
@@ -51,6 +51,16 @@ describe('AI Routing Security Tests', () => {
                 SERP_API_KEY: 'serp-key',
                 CUSTOM_API_KEY: 'custom-key',
             });
+            const claude45Result = filterApiKeysForServerSide(
+                apiKeys,
+                ChatMode.CLAUDE_SONNET_4_5,
+                false,
+            );
+            expect(claude45Result).toEqual({
+                ANTHROPIC_API_KEY: 'claude-key',
+                SERP_API_KEY: 'serp-key',
+                CUSTOM_API_KEY: 'custom-key',
+            });
 
             // Test BYOK OpenAI model (should keep only OPENAI_API_KEY)
             const openaiResult = filterApiKeysForServerSide(apiKeys, ChatMode.GPT_4o_Mini, false);

--- a/packages/common/tests/ai-routing.test.ts
+++ b/packages/common/tests/ai-routing.test.ts
@@ -34,6 +34,12 @@ describe('shouldUseServerSideAPI', () => {
                     hasVtPlus: true,
                 }),
             ).toBe(true);
+            expect(
+                shouldUseServerSideAPI({
+                    mode: ChatMode.CLAUDE_SONNET_4_5,
+                    hasVtPlus: true,
+                }),
+            ).toBe(true);
 
             expect(
                 shouldUseServerSideAPI({
@@ -57,6 +63,12 @@ describe('shouldUseServerSideAPI', () => {
                     hasVtPlus: false,
                 }),
             ).toBe(false);
+            expect(
+                shouldUseServerSideAPI({
+                    mode: ChatMode.CLAUDE_SONNET_4_5,
+                    hasVtPlus: false,
+                }),
+            ).toBe(false);
 
             expect(
                 shouldUseServerSideAPI({
@@ -76,6 +88,13 @@ describe('shouldUseServerSideAPI', () => {
                     deepResearch: true,
                 }),
             ).toBe(true);
+            expect(
+                shouldUseServerSideAPI({
+                    mode: ChatMode.CLAUDE_SONNET_4_5,
+                    hasVtPlus: true,
+                    deepResearch: true,
+                }),
+            ).toBe(true);
 
             expect(
                 shouldUseServerSideAPI({
@@ -91,6 +110,13 @@ describe('shouldUseServerSideAPI', () => {
                 shouldUseServerSideAPI({
                     mode: ChatMode.CLAUDE_4_SONNET,
                     hasVtPlus: false,
+                    proSearch: true,
+                }),
+            ).toBe(true);
+            expect(
+                shouldUseServerSideAPI({
+                    mode: ChatMode.CLAUDE_SONNET_4_5,
+                    hasVtPlus: true,
                     proSearch: true,
                 }),
             ).toBe(true);
@@ -113,6 +139,12 @@ describe('shouldUseServerSideAPI', () => {
                     hasVtPlus: false,
                 }),
             ).toBe(false);
+            expect(
+                shouldUseServerSideAPI({
+                    mode: ChatMode.CLAUDE_SONNET_4_5,
+                    hasVtPlus: false,
+                }),
+            ).toBe(false);
 
             expect(
                 shouldUseServerSideAPI({
@@ -127,6 +159,7 @@ describe('shouldUseServerSideAPI', () => {
 describe('needsServerSideForPlus', () => {
     it('should identify VT+ server models correctly', () => {
         expect(needsServerSideForPlus(ChatMode.CLAUDE_4_SONNET)).toBe(true);
+        expect(needsServerSideForPlus(ChatMode.CLAUDE_SONNET_4_5)).toBe(true);
         expect(needsServerSideForPlus(ChatMode.GPT_4o)).toBe(true);
         expect(needsServerSideForPlus(ChatMode.GEMINI_2_5_FLASH_LITE)).toBe(false);
         expect(needsServerSideForPlus(ChatMode.DEEPSEEK_R1)).toBe(true);
@@ -136,6 +169,7 @@ describe('needsServerSideForPlus', () => {
 describe('getProviderKeyToRemove', () => {
     it('should identify correct API key to remove', () => {
         expect(getProviderKeyToRemove(ChatMode.CLAUDE_4_SONNET)).toBe('ANTHROPIC_API_KEY');
+        expect(getProviderKeyToRemove(ChatMode.CLAUDE_SONNET_4_5)).toBe('ANTHROPIC_API_KEY');
         expect(getProviderKeyToRemove(ChatMode.GPT_4o)).toBe('OPENAI_API_KEY');
         expect(getProviderKeyToRemove(ChatMode.GEMINI_2_5_FLASH_LITE)).toBe('GEMINI_API_KEY');
     });
@@ -152,6 +186,12 @@ describe('filterApiKeysForServerSide', () => {
 
         const claudeFiltered = filterApiKeysForServerSide(apiKeys, ChatMode.CLAUDE_4_SONNET);
         expect(claudeFiltered).toEqual({
+            OPENAI_API_KEY: 'sk-123',
+            GEMINI_API_KEY: 'AIza123',
+            OTHER_KEY: 'other',
+        });
+        const claude45Filtered = filterApiKeysForServerSide(apiKeys, ChatMode.CLAUDE_SONNET_4_5);
+        expect(claude45Filtered).toEqual({
             OPENAI_API_KEY: 'sk-123',
             GEMINI_API_KEY: 'AIza123',
             OTHER_KEY: 'other',

--- a/packages/shared/__tests__/chat-mode-model-sync.test.ts
+++ b/packages/shared/__tests__/chat-mode-model-sync.test.ts
@@ -18,6 +18,9 @@ describe('ChatMode and ModelEnum Synchronization', () => {
             // Test specific known mappings
             expect(getModelFromChatMode(ChatMode.CLAUDE_4_1_OPUS)).toBe(ModelEnum.CLAUDE_4_1_OPUS);
             expect(getModelFromChatMode(ChatMode.CLAUDE_4_SONNET)).toBe(ModelEnum.CLAUDE_4_SONNET);
+            expect(getModelFromChatMode(ChatMode.CLAUDE_SONNET_4_5)).toBe(
+                ModelEnum.CLAUDE_SONNET_4_5,
+            );
             expect(getModelFromChatMode(ChatMode.CLAUDE_4_OPUS)).toBe(ModelEnum.CLAUDE_4_OPUS);
             expect(getModelFromChatMode(ChatMode.O1_MINI)).toBe(ModelEnum.O1_MINI);
             expect(getModelFromChatMode(ChatMode.O1)).toBe(ModelEnum.O1);
@@ -54,6 +57,9 @@ describe('ChatMode and ModelEnum Synchronization', () => {
             // Test that the unified function works correctly
             expect(getModelDisplayName(ChatMode.CLAUDE_4_1_OPUS)).toBe('Anthropic Claude 4.1 Opus');
             expect(getModelDisplayName(ChatMode.CLAUDE_4_SONNET)).toBe('Anthropic Claude 4 Sonnet');
+            expect(getModelDisplayName(ChatMode.CLAUDE_SONNET_4_5)).toBe(
+                'Anthropic Claude Sonnet 4.5',
+            );
             expect(getModelDisplayName(ChatMode.O1_MINI)).toBe('OpenAI o1-mini');
             expect(getModelDisplayName(ChatMode.KIMI_K2)).toBe('OpenRouter Kimi K2');
             expect(getModelDisplayName(ChatMode.GPT_OSS_120B)).toBe(
@@ -89,6 +95,7 @@ describe('ChatMode and ModelEnum Synchronization', () => {
         it('should have correct Claude model IDs', () => {
             expect(ModelEnum.CLAUDE_4_1_OPUS).toBe('claude-opus-4-1-20250805');
             expect(ModelEnum.CLAUDE_4_SONNET).toBe('claude-sonnet-4-20250514');
+            expect(ModelEnum.CLAUDE_SONNET_4_5).toBe('claude-sonnet-4-5');
             expect(ModelEnum.CLAUDE_4_OPUS).toBe('claude-opus-4-20250514');
         });
 

--- a/packages/shared/config/chat-mode.ts
+++ b/packages/shared/config/chat-mode.ts
@@ -22,6 +22,7 @@ export const ChatMode = {
 
     CLAUDE_4_1_OPUS: 'claude-opus-4-1-20250805',
     CLAUDE_4_SONNET: 'claude-sonnet-4-20250514',
+    CLAUDE_SONNET_4_5: 'claude-sonnet-4-5',
     CLAUDE_4_OPUS: 'claude-opus-4-20250514',
     DEEPSEEK_R1_FIREWORKS: 'deepseek-r1-fireworks',
     KIMI_K2_INSTRUCT_FIREWORKS: 'kimi-k2-instruct-fireworks',
@@ -157,6 +158,14 @@ export const ChatModeConfig: Record<
         imageUpload: true,
         multiModal: true,
         retry: true,
+        isAuthRequired: true,
+    },
+    [ChatMode.CLAUDE_SONNET_4_5]: {
+        webSearch: true,
+        imageUpload: true,
+        multiModal: true,
+        retry: true,
+        isNew: true,
         isAuthRequired: true,
     },
     [ChatMode.CLAUDE_4_OPUS]: {
@@ -446,6 +455,8 @@ export const getChatModeName = (mode: ChatMode) => {
             return 'Anthropic Claude 4.1 Opus';
         case ChatMode.CLAUDE_4_SONNET:
             return 'Anthropic Claude 4 Sonnet';
+        case ChatMode.CLAUDE_SONNET_4_5:
+            return 'Anthropic Claude Sonnet 4.5';
         case ChatMode.CLAUDE_4_OPUS:
             return 'Anthropic Claude 4 Opus';
         case ChatMode.O3:

--- a/packages/shared/utils/image-byok-validation.ts
+++ b/packages/shared/utils/image-byok-validation.ts
@@ -63,6 +63,7 @@ export const getRequiredApiKeyForChatMode = (chatMode: ChatMode): keyof ApiKeys 
 
         // Anthropic models
         [ChatMode.CLAUDE_4_SONNET]: 'ANTHROPIC_API_KEY',
+        [ChatMode.CLAUDE_SONNET_4_5]: 'ANTHROPIC_API_KEY',
         [ChatMode.CLAUDE_4_OPUS]: 'ANTHROPIC_API_KEY',
 
         // Google models


### PR DESCRIPTION
## Summary
- add the Claude Sonnet 4.5 chat mode, configuration, and naming to the shared chat-mode registry
- register the new Anthropic model across the AI model catalog, routing logic, BYOK flows, and associated tests
- refresh docs and memory-bank notes to highlight Claude Sonnet 4.5 availability alongside existing premium models

## Testing
- bunx dprint fmt
- bun run lint *(fails: oxlint command unavailable in PATH)*
- bunx oxlint *(fails: pre-existing lint issues reported across repository)*
- bun test packages/shared/__tests__/chat-mode-model-sync.test.ts *(fails: module resolution for path aliases under bun test)*

------
https://chatgpt.com/codex/tasks/task_e_68dacbcac3b483239dcea1f079475855