### PR TITLE
Remove image prompt tips banner and related preferences

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -22,6 +22,17 @@
 
 ---
 
+### ✅ Image Prompt Tips Removal
+
+**Date**: Current Session (July 2025)
+**Status**: Completed
+
+- Removed the Nano Banana image prompting tips banner from the chat input
+- Eliminated the related personalization toggle and persisted preferences
+- Pruned store state and storage keys that previously tracked banner visibility
+
+---
+
 ### ✅ Gemini Flash Lite BYOK Transition
 
 **Date**: Current Session (September 2025)

--- a/packages/common/components/settings-modal.tsx
+++ b/packages/common/components/settings-modal.tsx
@@ -2,7 +2,6 @@
 
 import { useChatEditor } from '@repo/common/hooks';
 import { useVtPlusAccess } from '@repo/common/hooks/use-subscription-access';
-import { STORAGE_KEYS } from '@repo/shared/config';
 import { useSession } from '@repo/shared/lib/auth-client';
 import {
     Alert,
@@ -562,8 +561,6 @@ export const PersonalizationSettings = ({ onClose }: PersonalizationSettingsProp
     const setCustomInstructions = useAppStore((state) => state.setCustomInstructions);
     const showExamplePrompts = useAppStore((state) => state.showExamplePrompts);
     const setShowExamplePrompts = useAppStore((state) => state.setShowExamplePrompts);
-    const showImageTips = useAppStore((state) => state.showImageTips);
-    const setShowImageTips = useAppStore((state) => state.setShowImageTips);
     const sidebarPlacement = useAppStore((state) => state.sidebarPlacement);
     const setSidebarPlacement = useAppStore((state) => state.setSidebarPlacement);
 
@@ -674,46 +671,6 @@ export const PersonalizationSettings = ({ onClose }: PersonalizationSettingsProp
                         </div>
                     </div>
 
-                    <div className='border-border/50 bg-muted/20 rounded-lg border p-4'>
-                        <div className='flex items-center justify-between'>
-                            <div className='space-y-1'>
-                                <div className='text-foreground text-sm font-medium'>
-                                    Image Prompt Tips Banner
-                                </div>
-                                <div className='text-muted-foreground text-xs'>
-                                    Permanently show or hide the image prompting tips below the chat
-                                    toolbar.
-                                </div>
-                            </div>
-                            <Button
-                                className='min-w-[60px]'
-                                onClick={() => {
-                                    const next = !showImageTips;
-                                    setShowImageTips(next);
-                                    try {
-                                        if (typeof window !== 'undefined') {
-                                            if (next) {
-                                                // Re-enable banner globally: clear dismissal token
-                                                window.localStorage.removeItem(
-                                                    STORAGE_KEYS.IMAGE_TIPS_DISMISSED,
-                                                );
-                                            } else {
-                                                // Persist dismissal to keep it hidden
-                                                window.localStorage.setItem(
-                                                    STORAGE_KEYS.IMAGE_TIPS_DISMISSED,
-                                                    '1',
-                                                );
-                                            }
-                                        }
-                                    } catch {}
-                                }}
-                                size='sm'
-                                variant={showImageTips ? 'default' : 'outline'}
-                            >
-                                {showImageTips ? 'On' : 'Off'}
-                            </Button>
-                        </div>
-                    </div>
                 </CardContent>
             </Card>
 

--- a/packages/common/store/app.store.ts
+++ b/packages/common/store/app.store.ts
@@ -52,8 +52,6 @@ type State = {
     useMathCalculator: boolean;
     useCharts: boolean;
     showSuggestions: boolean;
-    // Image tips banner preference
-    showImageTips: boolean;
     thinkingMode: {
         enabled: boolean;
         budget: number;
@@ -155,7 +153,6 @@ export const useAppStore = create<State & Actions>()(
                 useMathCalculator: false,
                 useCharts: false,
                 showSuggestions: false,
-                showImageTips: true,
                 thinkingMode: baseDefaults.thinkingMode,
                 geminiCaching: baseDefaults.geminiCaching,
                 profile: {
@@ -274,11 +271,6 @@ export const useAppStore = create<State & Actions>()(
 
                 setShowSuggestions: (show: boolean) => {
                     set({ showSuggestions: show });
-                },
-
-                // Image tips preference
-                setShowImageTips: (show: boolean) => {
-                    set({ showImageTips: show });
                 },
 
                 setThinkingMode: (mode: Partial<State['thinkingMode']>) => {
@@ -403,7 +395,6 @@ export const useAppStore = create<State & Actions>()(
                 useMathCalculator: state.useMathCalculator,
                 useCharts: state.useCharts,
                 showSuggestions: state.showSuggestions,
-                showImageTips: state.showImageTips,
                 thinkingMode: state.thinkingMode,
                 geminiCaching: state.geminiCaching,
                 profile: state.profile,

--- a/packages/shared/constants/storage.ts
+++ b/packages/shared/constants/storage.ts
@@ -42,16 +42,6 @@ export const STORAGE_KEYS = {
      */
     HAS_SEEN_INTRO: 'hasSeenIntro',
 
-    /**
-     * Key for hiding image prompt tips globally
-     */
-    IMAGE_TIPS_DISMISSED: 'image_tips_dismissed',
-
-    /**
-     * Key for per-thread image tips collapse state mapping
-     * Value shape: { [threadId: string]: 'collapsed' | 'expanded' }
-     */
-    IMAGE_TIPS_STATE: 'image_tips_state',
 } as const;
 
 export type StorageKey = (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS];


### PR DESCRIPTION
## Summary
- remove the Nano Banana image prompting tips banner from the chat input experience
- drop the personalization toggle and store persistence for the image tips setting
- delete the unused storage keys and document the change in the progress log

## Testing
- bun run fmt *(fails: dprint not found in environment)*
- bun run lint *(fails: oxlint not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc39f598883238c4aa458d93396a1