### PR TITLE
feat: add OpenAI Apps MCP server for VTChat

### DIFF
--- a/apps/vtchat-app/.gitignore
+++ b/apps/vtchat-app/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/apps/vtchat-app/app.json
+++ b/apps/vtchat-app/app.json
@@ -1,0 +1,53 @@
+{
+    "schema_version": "2025-01-01",
+    "name": {
+        "value": "VTChat Research Copilot",
+        "locale": "en-US"
+    },
+    "description": {
+        "value": "Expose VTChat's research agent to ChatGPT through the Apps SDK MCP server.",
+        "locale": "en-US"
+    },
+    "instructions": [
+        "Enable vtchat.analyze for research, synthesis, and summarization requests inside ChatGPT.",
+        "Render ui://widget/vtchat-conversation.html whenever the tool runs to show the brief."
+    ],
+    "server": {
+        "mcp_endpoint": "https://YOUR_DEPLOYED_DOMAIN/mcp",
+        "health_check": "/mcp"
+    },
+    "capabilities": {
+        "tools": [
+            {
+                "name": "vtchat.analyze",
+                "description": "Creates VTChat briefs with summary, insights, and actions.",
+                "input_schema": {
+                    "prompt": {
+                        "type": "string",
+                        "description": "Primary task or question for VTChat."
+                    },
+                    "context": {
+                        "type": "string",
+                        "description": "Optional background notes or source material."
+                    },
+                    "audience": {
+                        "type": "string",
+                        "description": "Audience to shape tone and recommendations."
+                    }
+                },
+                "output_template": "ui://widget/vtchat-conversation.html"
+            }
+        ],
+        "resources": [
+            {
+                "uri": "ui://widget/vtchat-conversation.html",
+                "mime_type": "text/html+skybridge",
+                "description": "Renders VTChat research briefs inside ChatGPT."
+            }
+        ]
+    },
+    "metadata": {
+        "icon": "https://vtchat.io.vn/icon-512x512.png",
+        "contact": "support@vtchat.io.vn"
+    }
+}

--- a/apps/vtchat-app/package.json
+++ b/apps/vtchat-app/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "@vtchat/apps-sdk-server",
+    "version": "0.1.0",
+    "description": "MCP server that exposes VTChat capabilities through the OpenAI Apps SDK",
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "dev": "bun --watch src/server.ts",
+        "start": "bun src/server.ts",
+        "type-check": "tsc --noEmit"
+    },
+    "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.20.0",
+        "openai": "^6.3.0",
+        "zod": "^3.24.1"
+    }
+}

--- a/apps/vtchat-app/src/server.ts
+++ b/apps/vtchat-app/src/server.ts
@@ -370,6 +370,7 @@ const handlePost = async (
     if (sessionId && sessions.has(sessionId)) {
         const context = sessions.get(sessionId);
         if (context) {
+            applyCors(req, res);
             await context.transport.handleRequest(req, res, body);
             return;
         }
@@ -411,6 +412,7 @@ const handlePost = async (
     };
 
     await server.connect(transport);
+    applyCors(req, res);
     await transport.handleRequest(req, res, body);
 };
 
@@ -447,6 +449,7 @@ const handleGetOrDelete = async (
         return;
     }
 
+    applyCors(req, res);
     await context.transport.handleRequest(req, res);
 };
 

--- a/apps/vtchat-app/src/server.ts
+++ b/apps/vtchat-app/src/server.ts
@@ -1,0 +1,500 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { randomUUID } from 'node:crypto';
+/* eslint-disable no-console */
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { OpenAI } from 'openai';
+import type { ResponseOutput, ResponseOutputContent } from 'openai/resources/responses';
+import { z } from 'zod';
+import { VTCHAT_CONVERSATION_TEMPLATE } from './templates/vtchat-conversation';
+
+type SessionContext = {
+    server: McpServer;
+    transport: StreamableHTTPServerTransport;
+};
+
+type AnalysisPayload = {
+    prompt: string;
+    context?: string;
+    audience?: string;
+};
+
+type StructuredAnalysis = {
+    summary: string;
+    insights: string[];
+    actionItems: string[];
+    followUps: string[];
+    audience: string;
+    generatedAt: string;
+};
+
+type ToolResult = {
+    content: { type: 'text'; text: string; }[];
+    structuredContent: StructuredAnalysis;
+    _meta: Record<string, unknown>;
+};
+
+const port = parseInt(process.env.VTCHAT_APPS_PORT ?? '4010', 10);
+const modelId = process.env.VTCHAT_APPS_MODEL_ID ?? 'gpt-4.1-mini';
+const allowedOrigins = (process.env.VTCHAT_APPS_ALLOWED_ORIGINS ?? '')
+    .split(',')
+    .map(origin => origin.trim())
+    .filter(origin => origin.length > 0);
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const sessions = new Map<string, SessionContext>();
+
+const schemaDefinition = {
+    name: 'vtchat_analysis',
+    schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+            summary: { type: 'string', description: 'High-level synthesis of the findings.' },
+            key_findings: {
+                type: 'array',
+                description: 'Key insights and evidence the user should know.',
+                items: { type: 'string' },
+            },
+            action_items: {
+                type: 'array',
+                description: 'Concrete next steps or recommendations.',
+                items: { type: 'string' },
+            },
+            follow_up_questions: {
+                type: 'array',
+                description: 'Follow-up prompts to deepen the investigation.',
+                items: { type: 'string' },
+            },
+        },
+        required: ['summary', 'key_findings', 'action_items', 'follow_up_questions'],
+    },
+} as const;
+
+const trimList = (items: string[], limit = 6): string[] => {
+    return items.filter(item => item.trim().length > 0).slice(0, limit);
+};
+
+const formatFallback = (payload: AnalysisPayload, reason: string): ToolResult => {
+    const audience = payload.audience?.trim().length ? payload.audience.trim() : 'General';
+    const summary = [
+        'VTChat could not reach the reasoning models because the OpenAI API key is missing or',
+        'invalid.',
+        'Set the OPENAI_API_KEY environment variable and restart the server.',
+    ].join(' ');
+
+    return {
+        content: [
+            {
+                type: 'text',
+                text: `${summary}\n\n${reason}`,
+            },
+        ],
+        structuredContent: {
+            summary,
+            insights: ['Configure OPENAI_API_KEY to unlock VTChat analysis.'],
+            actionItems: ['Provide a valid API key and redeploy the MCP server.'],
+            followUps: ['After configuring the key, ask VTChat to rerun this request.'],
+            audience,
+            generatedAt: new Date().toISOString(),
+        },
+        _meta: {
+            audience,
+            model: modelId,
+            reason,
+        },
+    };
+};
+
+const extractJsonText = (output: ResponseOutput | undefined): string | null => {
+    if (!output?.content) {
+        return null;
+    }
+
+    for (const entry of output.content as ResponseOutputContent[]) {
+        if (entry.type === 'output_text' && 'text' in entry) {
+            return entry.text;
+        }
+
+        if (entry.type === 'text' && 'text' in entry) {
+            return entry.text;
+        }
+
+        if (entry.type === 'json_schema' && 'json' in entry) {
+            return JSON.stringify(entry.json);
+        }
+
+        if (entry.type === 'tool_result' && 'result' in entry) {
+            return JSON.stringify(entry.result);
+        }
+    }
+
+    return null;
+};
+
+const callOpenAI = async (payload: AnalysisPayload): Promise<ToolResult> => {
+    if (!process.env.OPENAI_API_KEY) {
+        return formatFallback(payload, 'OPENAI_API_KEY is not defined.');
+    }
+
+    const promptSections = [
+        `Primary request:\n${payload.prompt.trim()}`,
+    ];
+
+    if (payload.context?.trim()) {
+        promptSections.push(`Additional context:\n${payload.context.trim()}`);
+    }
+
+    if (payload.audience?.trim()) {
+        promptSections.push(`Audience: ${payload.audience.trim()}`);
+    }
+
+    promptSections.push(
+        [
+            'Return a JSON object that summarizes the topic with summary and key findings,',
+            'plus action items and follow-up questions.',
+        ].join(' '),
+    );
+
+    try {
+        const response = await openai.responses.create({
+            model: modelId,
+            input: [
+                {
+                    role: 'system',
+                    content: [
+                        'You are VTChat, an orchestrator that produces structured research briefs.',
+                        'Always produce concise, factual, and actionable outputs.',
+                    ].join(' '),
+                },
+                { role: 'user', content: promptSections.join('\n\n') },
+            ],
+            response_format: { type: 'json_schema', json_schema: schemaDefinition },
+        });
+
+        const block = response.output?.[0];
+        const jsonText = extractJsonText(block) ?? response.output_text ?? '';
+        const parsed = JSON.parse(jsonText) as {
+            summary: string;
+            key_findings: string[];
+            action_items: string[];
+            follow_up_questions: string[];
+        };
+
+        const audience = payload.audience?.trim().length ? payload.audience.trim() : 'General';
+        const structuredContent: StructuredAnalysis = {
+            summary: parsed.summary,
+            insights: trimList(parsed.key_findings),
+            actionItems: trimList(parsed.action_items),
+            followUps: trimList(parsed.follow_up_questions),
+            audience,
+            generatedAt: new Date().toISOString(),
+        };
+
+        const messageLines = [
+            `Summary:\n${structuredContent.summary}`,
+            '',
+            'Key insights:',
+            ...structuredContent.insights.map(item => `• ${item}`),
+            '',
+            'Recommended actions:',
+            ...structuredContent.actionItems.map(item => `• ${item}`),
+            '',
+            'Follow-up prompts:',
+            ...structuredContent.followUps.map(item => `• ${item}`),
+        ];
+
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: messageLines.join('\n'),
+                },
+            ],
+            structuredContent,
+            _meta: {
+                audience,
+                model: modelId,
+            },
+        };
+    } catch (error) {
+        const reason = error instanceof Error ? error.message : 'Unknown error calling OpenAI.';
+        return formatFallback(payload, reason);
+    }
+};
+
+const createVtchatServer = (): McpServer => {
+    const server = new McpServer(
+        {
+            name: 'vtchat-app-server',
+            version: '1.0.0',
+            icons: [
+                {
+                    src: 'https://vtchat.io.vn/icons/app-icon.png',
+                    sizes: ['512x512'],
+                    mimeType: 'image/png',
+                },
+            ],
+            websiteUrl: 'https://vtchat.io.vn',
+        },
+        {
+            capabilities: {
+                logging: {},
+                tools: {},
+                resources: {},
+            },
+            instructions: [
+                'Use the vtchat.analyze tool whenever a user requests research, synthesis,',
+                'or structured insights.',
+                'Always rely on the tool output instead of answering directly.',
+            ].join(' '),
+        },
+    );
+
+    server.registerResource(
+        'vtchat-conversation-template',
+        'ui://widget/vtchat-conversation.html',
+        {
+            title: 'VTChat insight viewer',
+            description: 'Displays VTChat research briefs with structured insights.',
+            mimeType: 'text/html+skybridge',
+        },
+        async () => ({
+            contents: [
+                {
+                    uri: 'ui://widget/vtchat-conversation.html',
+                    mimeType: 'text/html+skybridge',
+                    text: VTCHAT_CONVERSATION_TEMPLATE,
+                },
+            ],
+        }),
+    );
+
+    const inputSchema = {
+        prompt: z.string().min(1).describe('Primary user question or task for VTChat'),
+        context: z.string().optional().describe('Optional background details or source notes'),
+        audience: z.string().optional().describe('Intended audience for tone and framing'),
+    } satisfies Record<string, unknown>;
+
+    server.registerTool(
+        'vtchat.analyze',
+        {
+            title: 'VTChat Deep Analysis',
+            description: 'Generates structured VTChat research briefs for complex questions.',
+            inputSchema,
+            _meta: {
+                'openai/outputTemplate': 'ui://widget/vtchat-conversation.html',
+                'openai/toolInvocation/invoking': 'Synthesizing VTChat insights…',
+                'openai/toolInvocation/invoked': 'VTChat analysis ready',
+                'openai/securitySchemes': [],
+                'openai/widgetAccessible': true,
+            },
+        },
+        async (input) => {
+            const payload: AnalysisPayload = {
+                prompt: input.prompt,
+                context: input.context,
+                audience: input.audience,
+            };
+
+            return callOpenAI(payload);
+        },
+    );
+
+    return server;
+};
+
+const resolveOrigin = (req: IncomingMessage): string | undefined => {
+    const originHeader = req.headers.origin;
+    if (!originHeader) {
+        return allowedOrigins.length === 0 ? '*' : allowedOrigins[0];
+    }
+
+    if (allowedOrigins.length === 0 || allowedOrigins.includes(originHeader)) {
+        return originHeader;
+    }
+
+    return undefined;
+};
+
+const applyCors = (req: IncomingMessage, res: ServerResponse): void => {
+    const origin = resolveOrigin(req);
+    if (origin) {
+        res.setHeader('Access-Control-Allow-Origin', origin);
+    }
+
+    res.setHeader('Access-Control-Allow-Methods', 'GET,POST,DELETE,OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, Mcp-Session-Id');
+    res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id');
+};
+
+const sendJson = (
+    req: IncomingMessage,
+    res: ServerResponse,
+    status: number,
+    payload: unknown,
+): void => {
+    applyCors(req, res);
+    res.statusCode = status;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(payload));
+};
+
+const readBody = async (req: IncomingMessage): Promise<unknown> => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+        chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+    }
+
+    if (chunks.length === 0) {
+        return undefined;
+    }
+
+    const raw = Buffer.concat(chunks).toString('utf8');
+    if (!raw.trim()) {
+        return undefined;
+    }
+
+    return JSON.parse(raw);
+};
+
+const handlePost = async (
+    req: IncomingMessage,
+    res: ServerResponse,
+    body: unknown,
+): Promise<void> => {
+    const sessionIdHeader = req.headers['mcp-session-id'];
+    const sessionId = Array.isArray(sessionIdHeader) ? sessionIdHeader[0] : sessionIdHeader;
+
+    if (sessionId && sessions.has(sessionId)) {
+        const context = sessions.get(sessionId);
+        if (context) {
+            await context.transport.handleRequest(req, res, body);
+            return;
+        }
+    }
+
+    if (!isInitializeRequest(body)) {
+        sendJson(req, res, 400, {
+            jsonrpc: '2.0',
+            error: {
+                code: -32000,
+                message: 'Initialization required before issuing tool calls.',
+            },
+            id: null,
+        });
+        return;
+    }
+
+    const server = createVtchatServer();
+    const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (newSessionId) => {
+            sessions.set(newSessionId, { server, transport });
+        },
+    });
+
+    transport.onclose = () => {
+        const activeId = transport.sessionId;
+        if (activeId) {
+            sessions.delete(activeId);
+        }
+    };
+
+    transport.onerror = (error) => {
+        const activeId = transport.sessionId;
+        if (activeId) {
+            sessions.delete(activeId);
+        }
+        console.error('MCP transport error', error);
+    };
+
+    await server.connect(transport);
+    await transport.handleRequest(req, res, body);
+};
+
+const handleGetOrDelete = async (
+    method: 'GET' | 'DELETE',
+    req: IncomingMessage,
+    res: ServerResponse,
+): Promise<void> => {
+    const sessionIdHeader = req.headers['mcp-session-id'];
+    const sessionId = Array.isArray(sessionIdHeader) ? sessionIdHeader[0] : sessionIdHeader;
+
+    if (!sessionId || !sessions.has(sessionId)) {
+        sendJson(req, res, 400, {
+            jsonrpc: '2.0',
+            error: {
+                code: -32000,
+                message: 'Invalid or missing MCP session id.',
+            },
+            id: null,
+        });
+        return;
+    }
+
+    const context = sessions.get(sessionId);
+    if (!context) {
+        sendJson(req, res, 404, {
+            jsonrpc: '2.0',
+            error: {
+                code: -32004,
+                message: 'Session not found.',
+            },
+            id: null,
+        });
+        return;
+    }
+
+    await context.transport.handleRequest(req, res);
+};
+
+const server = createServer(async (req, res) => {
+    try {
+        if (!req.url) {
+            sendJson(req, res, 404, { message: 'Not Found' });
+            return;
+        }
+
+        const url = new URL(req.url, `http://${req.headers.host ?? 'localhost'}`);
+        if (url.pathname !== '/mcp') {
+            sendJson(req, res, 404, { message: 'Route not found' });
+            return;
+        }
+
+        if (req.method === 'OPTIONS') {
+            applyCors(req, res);
+            res.statusCode = 204;
+            res.end();
+            return;
+        }
+
+        if (req.method === 'POST') {
+            const body = await readBody(req);
+            await handlePost(req, res, body);
+            return;
+        }
+
+        if (req.method === 'GET' || req.method === 'DELETE') {
+            await handleGetOrDelete(req.method, req, res);
+            return;
+        }
+
+        sendJson(req, res, 405, { message: 'Method not allowed' });
+    } catch (error) {
+        console.error('Unhandled server error', error);
+        sendJson(req, res, 500, {
+            jsonrpc: '2.0',
+            error: {
+                code: -32603,
+                message: 'Internal server error',
+            },
+            id: null,
+        });
+    }
+});
+
+server.listen(port, () => {
+    console.log(`VTChat Apps SDK server listening on port ${port}`);
+});

--- a/apps/vtchat-app/src/server.ts
+++ b/apps/vtchat-app/src/server.ts
@@ -271,11 +271,11 @@ const createVtchatServer = (): McpServer => {
         }),
     );
 
-    const inputSchema = {
+    const inputSchema = z.object({
         prompt: z.string().min(1).describe('Primary user question or task for VTChat'),
         context: z.string().optional().describe('Optional background details or source notes'),
         audience: z.string().optional().describe('Intended audience for tone and framing'),
-    } satisfies Record<string, unknown>;
+    });
 
     server.registerTool(
         'vtchat.analyze',

--- a/apps/vtchat-app/src/templates/vtchat-conversation.ts
+++ b/apps/vtchat-app/src/templates/vtchat-conversation.ts
@@ -1,0 +1,248 @@
+export const VTCHAT_CONVERSATION_TEMPLATE = `
+<div id="vtchat-root">
+    <style>
+        :root {
+            color-scheme: dark;
+            font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+        }
+
+        body {
+            margin: 0;
+            padding: 0;
+        }
+
+        #vtchat-root {
+            background: #0f1115;
+            color: #f5f7fa;
+            min-height: 100vh;
+            padding: 24px;
+        }
+
+        .vtchat-container {
+            max-width: 880px;
+            margin: 0 auto;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .vtchat-header {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .vtchat-header h1 {
+            font-size: 22px;
+            margin: 0;
+        }
+
+        .vtchat-meta {
+            color: #8a97a5;
+            font-size: 13px;
+        }
+
+        .vtchat-card {
+            background: #151821;
+            border: 1px solid #1f2430;
+            border-radius: 12px;
+            padding: 16px 18px;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            box-shadow: 0 12px 32px rgba(2, 6, 23, 0.35);
+        }
+
+        .vtchat-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 16px;
+        }
+
+        .vtchat-section-title {
+            font-size: 14px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            text-transform: uppercase;
+            color: #9bb5d0;
+            margin: 0 0 8px 0;
+        }
+
+        ul.vtchat-list {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        ul.vtchat-list li {
+            position: relative;
+            padding-left: 16px;
+            color: #d6e1f0;
+            line-height: 1.45;
+        }
+
+        ul.vtchat-list li::before {
+            content: '';
+            position: absolute;
+            left: 4px;
+            top: 9px;
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: #48a3ff;
+        }
+
+        .vtchat-empty {
+            color: #8a97a5;
+            font-size: 13px;
+        }
+
+        .vtchat-summary {
+            font-size: 16px;
+            line-height: 1.6;
+            color: #f5f7fa;
+            margin: 0;
+        }
+
+        .vtchat-footer {
+            display: flex;
+            justify-content: space-between;
+            font-size: 12px;
+            color: #6a7686;
+        }
+
+        .vtchat-footer span {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .vtchat-footer svg {
+            width: 14px;
+            height: 14px;
+            stroke: currentColor;
+        }
+    </style>
+    <div class="vtchat-container">
+        <header class="vtchat-header">
+            <h1>VTChat Research Brief</h1>
+            <div class="vtchat-meta" id="vtchat-meta">Waiting for VTChat to generate insights…</div>
+        </header>
+        <article class="vtchat-card">
+            <p class="vtchat-summary" id="vtchat-summary"></p>
+        </article>
+        <section class="vtchat-grid">
+            <article class="vtchat-card">
+                <h2 class="vtchat-section-title">Key insights</h2>
+                <ul class="vtchat-list" id="vtchat-insights"></ul>
+            </article>
+            <article class="vtchat-card">
+                <h2 class="vtchat-section-title">Recommended actions</h2>
+                <ul class="vtchat-list" id="vtchat-actions"></ul>
+            </article>
+            <article class="vtchat-card">
+                <h2 class="vtchat-section-title">Follow-up prompts</h2>
+                <ul class="vtchat-list" id="vtchat-followups"></ul>
+            </article>
+        </section>
+        <footer class="vtchat-footer">
+            <span id="vtchat-status"></span>
+            <span>
+                <svg viewBox="0 0 24 24" fill="none">
+                    <path d="M4 19h16M4 5h16" stroke-width="1.5" stroke-linecap="round"></path>
+                </svg>
+                Powered by VTChat Apps SDK bridge
+            </span>
+        </footer>
+    </div>
+    <script type="module">
+        const summaryEl = document.getElementById('vtchat-summary');
+        const insightsEl = document.getElementById('vtchat-insights');
+        const actionsEl = document.getElementById('vtchat-actions');
+        const followUpsEl = document.getElementById('vtchat-followups');
+        const metaEl = document.getElementById('vtchat-meta');
+        const statusEl = document.getElementById('vtchat-status');
+
+        const openaiBridge = window.openai ?? {};
+
+        const renderList = (container, items) => {
+            container.replaceChildren();
+
+            if (!Array.isArray(items) || items.length === 0) {
+                const empty = document.createElement('li');
+                empty.className = 'vtchat-empty';
+                empty.textContent = 'No data available yet.';
+                container.appendChild(empty);
+                return;
+            }
+
+            const safeItems = items
+                .map(item => (typeof item === 'string' ? item : JSON.stringify(item)))
+                .filter(Boolean);
+
+            safeItems.forEach(text => {
+                const element = document.createElement('li');
+                element.textContent = text;
+                container.appendChild(element);
+            });
+        };
+
+        const renderPayload = payload => {
+            if (!payload) {
+                return;
+            }
+
+            const structured = payload.structuredContent ?? {};
+            const meta = payload._meta ?? {};
+            const summary = structured.summary ?? '';
+            const insights = structured.insights ?? structured.keyFindings ?? [];
+            const actions = structured.actionItems ?? structured.actions ?? [];
+            const followUps = structured.followUps ?? structured.followUpQuestions ?? [];
+            const timestamp = structured.generatedAt ?? structured.timestamp;
+
+            summaryEl.textContent = summary || 'VTChat will populate this summary shortly.';
+            renderList(insightsEl, insights);
+            renderList(actionsEl, actions);
+            renderList(followUpsEl, followUps);
+
+            const audience = structured.audience ?? meta.audience ?? 'General';
+            const model = meta.model ?? 'Unspecified model';
+            const clock = timestamp ? new Date(timestamp).toLocaleString() : 'Pending response';
+            metaEl.textContent = 'Audience: ' + audience + ' - Model: ' + model;
+            statusEl.textContent = 'Last updated ' + clock;
+        };
+
+        const handleUpdate = detail => {
+            if (!detail) {
+                return;
+            }
+
+            if (detail.detail) {
+                renderPayload(detail.detail);
+                return;
+            }
+
+            renderPayload(detail);
+        };
+
+        if (typeof openaiBridge.subscribeToToolOutput === 'function') {
+            openaiBridge.subscribeToToolOutput(event => handleUpdate(event));
+        }
+
+        if (typeof openaiBridge.subscribeToToolInvocation === 'function') {
+            openaiBridge.subscribeToToolInvocation(event => handleUpdate(event));
+        }
+
+        if (openaiBridge.toolInvocation) {
+            handleUpdate(openaiBridge.toolInvocation);
+        }
+
+        if (openaiBridge.toolOutput) {
+            handleUpdate(openaiBridge.toolOutput);
+        }
+    </script>
+</div>
+`.trim();

--- a/apps/vtchat-app/tsconfig.json
+++ b/apps/vtchat-app/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "@repo/typescript-config/base.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "rootDir": "src",
+        "tsBuildInfoFile": "dist/.tsbuildinfo"
+    },
+    "include": ["src/**/*"],
+    "exclude": ["dist", "node_modules"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -93,6 +93,15 @@
         "vitest": "^3.2.4",
       },
     },
+    "apps/vtchat-app": {
+      "name": "@vtchat/apps-sdk-server",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.20.0",
+        "openai": "^6.3.0",
+        "zod": "^3.24.1",
+      },
+    },
     "apps/web": {
       "name": "@vtchat/web",
       "version": "1.0.0",
@@ -786,6 +795,8 @@
 
     "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
 
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.20.0", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-kOQ4+fHuT4KbR2iq2IjeV32HiihueuOf1vJkq18z08CLZ1UQrTc8BXJpVfxZkq45+inLLD+D4xx4nBjUelJa4Q=="],
+
     "@monogrid/gainmap-js": ["@monogrid/gainmap-js@3.1.0", "", { "dependencies": { "promise-worker-transferable": "^1.0.4" }, "peerDependencies": { "three": ">= 0.159.0" } }, "sha512-Obb0/gEd/HReTlg8ttaYk+0m62gQJmCblMOjHSMHRrBP2zdfKMHLCRbh/6ex9fSUJMKdjjIEiohwkbGD3wj2Nw=="],
 
     "@mozilla/readability": ["@mozilla/readability@0.6.0", "", {}, "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ=="],
@@ -1440,6 +1451,8 @@
 
     "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
+    "@vtchat/apps-sdk-server": ["@vtchat/apps-sdk-server@workspace:apps/vtchat-app"],
+
     "@vtchat/web": ["@vtchat/web@workspace:apps/web"],
 
     "@vue/compiler-core": ["@vue/compiler-core@3.5.18", "", { "dependencies": { "@babel/parser": "^7.28.0", "@vue/shared": "3.5.18", "entities": "^4.5.0", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw=="],
@@ -1477,6 +1490,8 @@
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
     "ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
+
+    "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
     "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
@@ -1984,6 +1999,8 @@
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
     "eventsource-parser": ["eventsource-parser@1.1.2", "", {}, "sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA=="],
 
     "evp_bytestokey": ["evp_bytestokey@1.0.3", "", { "dependencies": { "md5.js": "^1.3.4", "safe-buffer": "^5.1.1" } }, "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA=="],
@@ -1993,6 +2010,8 @@
     "expect-type": ["expect-type@1.2.2", "", {}, "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA=="],
 
     "express": ["express@4.21.2", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "1.20.3", "content-disposition": "0.5.4", "content-type": "~1.0.4", "cookie": "0.7.1", "cookie-signature": "1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "1.3.1", "fresh": "0.5.2", "http-errors": "2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "0.1.12", "proxy-addr": "~2.0.7", "qs": "6.13.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "0.19.0", "serve-static": "1.16.2", "setprototypeof": "1.2.0", "statuses": "2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA=="],
+
+    "express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
 
     "exsolve": ["exsolve@1.0.7", "", {}, "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw=="],
 
@@ -2007,6 +2026,8 @@
     "fast-equals": ["fast-equals@5.2.2", "", {}, "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-redact": ["fast-redact@3.5.0", "", {}, "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A=="],
 
@@ -2302,6 +2323,8 @@
 
     "json-schema-to-zod": ["json-schema-to-zod@2.6.1", "", { "bin": { "json-schema-to-zod": "dist/cjs/cli.js" } }, "sha512-uiHmWH21h9FjKJkRBntfVGTLpYlCZ1n98D0izIlByqQLqpmkQpNTBtfbdP04Na6+43lgsvrShFh2uWLkQDKJuQ=="],
 
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsondiffpatch": ["jsondiffpatch@0.6.0", "", { "dependencies": { "@types/diff-match-patch": "^1.0.36", "chalk": "^5.3.0", "diff-match-patch": "^1.0.5" }, "bin": { "jsondiffpatch": "bin/jsondiffpatch.js" } }, "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ=="],
@@ -2552,9 +2575,9 @@
 
     "mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
 
-    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
-    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+    "mime-types": ["mime-types@3.0.1", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA=="],
 
     "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
 
@@ -2754,6 +2777,8 @@
 
     "pino-std-serializers": ["pino-std-serializers@7.0.0", "", {}, "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="],
 
+    "pkce-challenge": ["pkce-challenge@5.0.0", "", {}, "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ=="],
+
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
     "playwright": ["playwright@1.54.2", "", { "dependencies": { "playwright-core": "1.54.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw=="],
@@ -2896,7 +2921,7 @@
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
-    "raw-body": ["raw-body@2.5.2", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.4.24", "unpipe": "1.0.0" } }, "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA=="],
+    "raw-body": ["raw-body@3.0.1", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.7.0", "unpipe": "1.0.0" } }, "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA=="],
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
@@ -3019,6 +3044,8 @@
     "rou3": ["rou3@0.5.1", "", {}, "sha512-OXMmJ3zRk2xeXFGfA3K+EOPHC5u7RDFG7lIOx0X1pdnhUkI8MdVrbV+sNsD80ElpUZ+MRHdyxPnFthq9VHs8uQ=="],
 
     "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 
@@ -3352,6 +3379,8 @@
 
     "update-browserslist-db": ["update-browserslist-db@1.1.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw=="],
 
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
     "url": ["url@0.11.4", "", { "dependencies": { "punycode": "^1.4.1", "qs": "^6.12.3" } }, "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg=="],
 
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
@@ -3576,6 +3605,12 @@
 
     "@langchain/openai/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@modelcontextprotocol/sdk/eventsource-parser": ["eventsource-parser@3.0.3", "", {}, "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA=="],
+
+    "@modelcontextprotocol/sdk/express": ["express@5.1.0", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.0", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "@mrleebo/prisma-ast/lilconfig": ["lilconfig@2.1.0", "", {}, "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="],
 
     "@neondatabase/serverless/@types/node": ["@types/node@22.17.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ=="],
@@ -3594,9 +3629,13 @@
 
     "@repo/common/zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
-    "@repo/shared/@types/node": ["@types/node@24.3.1", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g=="],
+    "@repo/orchestrator/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@repo/shared/@types/node": ["@types/node@24.7.2", "", { "dependencies": { "undici-types": "~7.14.0" } }, "sha512-/NbVmcGTP+lj5oa4yiYxxeBjRivKQ5Ns1eSZeB99ExsEQ6rX5XYU1Zy/gGxY/ilqtD4Etx9mKyrPxZRetiahhA=="],
 
     "@repo/shared/lucide-react": ["lucide-react@0.525.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ=="],
+
+    "@repo/shared/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@repo/tailwind-config/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
@@ -3605,6 +3644,8 @@
     "@repo/ui/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "@repo/ui/react": ["react@19.1.1", "", {}, "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ=="],
+
+    "@repo/ui/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@repo/ui/vaul": ["vaul@1.1.2", "", { "dependencies": { "@radix-ui/react-dialog": "^1.1.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA=="],
 
@@ -3644,6 +3685,10 @@
 
     "@types/prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
+    "@vtchat/apps-sdk-server/openai": ["openai@6.3.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-E6vOGtZvdcb4yXQ5jXvDlUG599OhIkb/GjBLZXS+qk0HF+PJReIldEc9hM8Ft81vn+N6dRdFRb7BZNK8bbvXrw=="],
+
+    "@vtchat/apps-sdk-server/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "@vtchat/web/@types/node": ["@types/node@20.19.9", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw=="],
 
     "@vtchat/web/better-auth": ["better-auth@1.2.10", "", { "dependencies": { "@better-auth/utils": "0.2.5", "@better-fetch/fetch": "^1.1.18", "@noble/ciphers": "^0.6.0", "@noble/hashes": "^1.6.1", "@simplewebauthn/browser": "^13.0.0", "@simplewebauthn/server": "^13.0.0", "better-call": "^1.0.8", "defu": "^6.1.4", "jose": "^5.9.6", "kysely": "^0.28.2", "nanostores": "^0.11.3", "zod": "^3.24.1" } }, "sha512-nEj1RG4DdLUuJiV5CR93ORyPCptGRBwksaPPCkUtGo9ka+UIlTpaiKoTaTqVLLYlqwX4bOj9tJ32oBNdf2G3Kg=="],
@@ -3666,6 +3711,8 @@
 
     "@vue/compiler-sfc/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
+    "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "ai/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -3683,6 +3730,8 @@
     "body-parser/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "body-parser/qs": ["qs@6.13.0", "", { "dependencies": { "side-channel": "^1.0.6" } }, "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg=="],
+
+    "body-parser/raw-body": ["raw-body@2.5.2", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.4.24", "unpipe": "1.0.0" } }, "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA=="],
 
     "braintrust/@next/env": ["@next/env@14.2.31", "", {}, "sha512-X8VxxYL6VuezrG82h0pUA1V+DuTSJp7Nv15bxq3ivrFqZLjx81rfeHMWOE9T0jm1n3DtHGv8gdn6B0T0kr0D3Q=="],
 
@@ -3720,6 +3769,8 @@
 
     "elliptic/bn.js": ["bn.js@4.12.2", "", {}, "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="],
 
+    "eventsource/eventsource-parser": ["eventsource-parser@3.0.3", "", {}, "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA=="],
+
     "express/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "express/qs": ["qs@6.13.0", "", { "dependencies": { "side-channel": "^1.0.6" } }, "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg=="],
@@ -3729,6 +3780,8 @@
     "filelist/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
 
     "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "formdata-node/web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
 
@@ -3810,7 +3863,7 @@
 
     "public-encrypt/bn.js": ["bn.js@4.12.2", "", {}, "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="],
 
-    "raw-body/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
+    "raw-body/iconv-lite": ["iconv-lite@0.7.0", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ=="],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
@@ -3819,6 +3872,10 @@
     "react-scan/@clack/prompts": ["@clack/prompts@0.8.2", "", { "dependencies": { "@clack/core": "0.3.5", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-6b9Ab2UiZwJYA9iMyboYyW9yJvAO9V753ZhS+DHKEjZRKAxPPOb7MXXu84lsPFG+vZt6FRFniZ8rXi+zCIw4yQ=="],
 
     "react-scan/@types/node": ["@types/node@20.19.9", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw=="],
+
+    "router/is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
     "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
@@ -3850,11 +3907,15 @@
 
     "tunnel-rat/zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
+    "type-is/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "unist-util-remove/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "unist-util-remove/unist-util-is": ["unist-util-is@5.2.1", "", { "dependencies": { "@types/unist": "^2.0.0" } }, "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw=="],
 
     "unist-util-remove/unist-util-visit-parents": ["unist-util-visit-parents@5.1.3", "", { "dependencies": { "@types/unist": "^2.0.0", "unist-util-is": "^5.0.0" } }, "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg=="],
+
+    "uri-js/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
@@ -3976,6 +4037,26 @@
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
+    "@modelcontextprotocol/sdk/express/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "@modelcontextprotocol/sdk/express/body-parser": ["body-parser@2.2.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.0", "http-errors": "^2.0.0", "iconv-lite": "^0.6.3", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.0", "type-is": "^2.0.0" } }, "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg=="],
+
+    "@modelcontextprotocol/sdk/express/content-disposition": ["content-disposition@1.0.0", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg=="],
+
+    "@modelcontextprotocol/sdk/express/cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "@modelcontextprotocol/sdk/express/finalhandler": ["finalhandler@2.1.0", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q=="],
+
+    "@modelcontextprotocol/sdk/express/fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "@modelcontextprotocol/sdk/express/merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "@modelcontextprotocol/sdk/express/send": ["send@1.2.0", "", { "dependencies": { "debug": "^4.3.5", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.0", "mime-types": "^3.0.1", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.1" } }, "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw=="],
+
+    "@modelcontextprotocol/sdk/express/serve-static": ["serve-static@2.2.0", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ=="],
+
+    "@modelcontextprotocol/sdk/express/type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
     "@neondatabase/serverless/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@openrouter/ai-sdk-provider/@ai-sdk/provider-utils/nanoid": ["nanoid@3.3.6", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="],
@@ -3985,6 +4066,8 @@
     "@repo/ai/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@repo/common/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "@repo/shared/@types/node/undici-types": ["undici-types@7.14.0", "", {}, "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA=="],
 
     "@repo/tailwind-config/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -4040,6 +4123,8 @@
 
     "@vue/compiler-sfc/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "body-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "braintrust/ai/@ai-sdk/provider": ["@ai-sdk/provider@0.0.26", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-dQkfBDs2lTYpKM8389oopPdQgIU007GQyCbuPPrV+K6MtSII3HBfE0stUIMXUb44L+LK1t6GXPP7wjSzjO6uKg=="],
@@ -4077,6 +4162,8 @@
     "express/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "fs-minipass/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
@@ -4184,7 +4271,11 @@
 
     "tsconfig-paths-webpack-plugin/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "type-is/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "vite/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "@modelcontextprotocol/sdk/express/type-is/media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
     "@vtchat/web/next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 

--- a/docs/apps-sdk-integration.md
+++ b/docs/apps-sdk-integration.md
@@ -1,0 +1,65 @@
+# VTChat Apps SDK Integration
+
+This document describes how to run the VTChat MCP server that powers the OpenAI Apps SDK
+integration. The server exposes the `vtchat.analyze` tool and a corresponding UI component so
+ChatGPT can render VTChat research briefs inside the client.
+
+## Package overview
+
+The MCP server lives in `apps/vtchat-app` and ships with the following pieces:
+
+- `src/server.ts` – Node HTTP server that implements the Apps SDK Streamable HTTP transport.
+- `src/templates/vtchat-conversation.ts` – HTML/JS template rendered inside ChatGPT for structured
+  responses.
+- `app.json` – Reference manifest that lists the tool, resource template, and connector metadata.
+
+## Environment variables
+
+Set the following variables before launching the server:
+
+- `OPENAI_API_KEY` – Required to call the Responses API and build structured VTChat briefs.
+- `VTCHAT_APPS_PORT` – Optional port for the HTTP server (defaults to `4010`).
+- `VTCHAT_APPS_MODEL_ID` – Optional model override (`gpt-4.1-mini` is the default).
+- `VTCHAT_APPS_ALLOWED_ORIGINS` – Comma-separated allow-list for CORS headers. Leave empty to allow
+  all origins during development.
+
+## Installing dependencies
+
+```bash
+bun install
+```
+
+## Running the MCP server
+
+```bash
+bun --filter @vtchat/apps-sdk-server start
+```
+
+The server exposes `/mcp` with support for `POST`, `GET`, and `DELETE` so it can accept
+Streamable HTTP traffic from ChatGPT and other Apps SDK clients. Logs surface missing configuration
+(such as an absent `OPENAI_API_KEY`) and each connected session.
+
+## Testing with MCP Inspector
+
+1. Launch the server locally.
+2. Start [MCP Inspector](https://modelcontextprotocol.io/inspector).
+3. Connect to `http://localhost:<port>/mcp`.
+4. Verify that the `vtchat.analyze` tool appears and that invoking it returns structured content and
+   logs.
+
+## Connecting to ChatGPT (developer mode)
+
+1. Deploy the server behind an HTTPS endpoint (Ngrok works for local testing).
+2. In ChatGPT, open **Settings → Connectors → Create**.
+3. Provide the connector name, description, and the public `/mcp` URL.
+4. Enable the connector in a conversation and prompt, for example, “Use VTChat to summarise the
+   latest paper on retrieval-augmented generation.”
+
+## Expected behaviour
+
+- The tool responds with JSON structured output backed by the VTChat HTML template.
+- `structuredContent` includes summary, key insights, recommended actions, follow-up prompts,
+  audience metadata, and timestamps.
+- The fallback path guides operators to configure `OPENAI_API_KEY` when missing or misconfigured.
+
+Refer to the OpenAI Apps SDK documentation for additional deployment and metadata guidelines.

--- a/memory-bank/2025-10-11-apps-sdk-integration.md
+++ b/memory-bank/2025-10-11-apps-sdk-integration.md
@@ -1,0 +1,6 @@
+# VTChat Apps SDK Server Integration
+
+- Added `apps/vtchat-app` MCP server package that proxies analysis requests through OpenAI Responses API.
+- Registered `vtchat.analyze` tool with structured JSON schema and VTChat HTML widget resource.
+- Documented setup steps in `docs/apps-sdk-integration.md` for running via Bun and connecting with MCP Inspector.
+- Added app manifest (`app.json`) for ChatGPT Apps configuration.


### PR DESCRIPTION
## Summary
- add the `apps/vtchat-app` MCP package that exposes the `vtchat.analyze` tool through the Apps SDK server transport
- provide a VTChat HTML conversation template and manifest so ChatGPT can render structured research briefs
- document setup and capture the integration details in the memory bank for future reference

## Testing
- ✅ `bun run fmt`
- ❌ `bun run lint` *(fails because of pre-existing unused variable and exhaustive-deps issues in other packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ea99a272b48323b09531c484010f8c