### PR TITLE
Shorten metadata titles for marketing pages

### DIFF
--- a/apps/web/app/about/page.tsx
+++ b/apps/web/app/about/page.tsx
@@ -19,7 +19,7 @@ import Link from 'next/link';
 export const dynamic = 'force-static';
 
 export const metadata: Metadata = {
-    title: 'About VT - Advanced AI Platform with Nano Banana Image Editing & Deep Learning',
+    title: 'About VT | VT AI Platform',
     description:
         "Learn about VT's advanced AI platform featuring the Conversational image editor (Nano Banana), generative AI, deep learning, natural language processing (NLP), and large language models (LLMs). Privacy-first AI systems with revolutionary image editing.",
     keywords: [
@@ -38,7 +38,7 @@ export const metadata: Metadata = {
         'iterative image editing',
     ],
     openGraph: {
-        title: 'About VT - Advanced AI Platform with Nano Banana Image Editing & Deep Learning',
+        title: 'About VT | VT AI Platform',
         description:
             "Learn about VT's advanced AI platform featuring the Conversational image editor (Nano Banana), generative AI, deep learning, and large language models. Privacy-first AI systems.",
         type: 'website',

--- a/apps/web/app/ai-glossary/page.tsx
+++ b/apps/web/app/ai-glossary/page.tsx
@@ -16,7 +16,7 @@ import type { Metadata } from 'next';
 export const dynamic = 'force-static';
 
 export const metadata: Metadata = {
-    title: 'AI Glossary - Conversational Image Editing & Artificial Intelligence Terms | VT',
+    title: 'AI Glossary | VT AI Platform',
     description:
         'Comprehensive AI glossary covering conversational image editing (Nano Banana), artificial intelligence, generative AI, deep learning, natural language processing (NLP), large language models (LLMs), machine learning, computer vision, and AI systems terminology.',
     keywords: [
@@ -36,7 +36,7 @@ export const metadata: Metadata = {
         'iterative image editing terms',
     ],
     openGraph: {
-        title: 'AI Glossary - Conversational Image Editing & Artificial Intelligence Terms',
+        title: 'AI Glossary | VT AI Platform',
         description:
             'Complete glossary of AI terms including conversational image editing (Nano Banana), generative AI, deep learning, natural language processing, and machine learning definitions.',
         type: 'website',

--- a/apps/web/app/ai-resources/page.tsx
+++ b/apps/web/app/ai-resources/page.tsx
@@ -14,8 +14,7 @@ import type { Metadata } from 'next';
 export const dynamic = 'force-static';
 
 export const metadata: Metadata = {
-    title:
-        'AI Resources - Learn Conversational Image Editing, Artificial Intelligence & Machine Learning | VT',
+    title: 'AI Resources | VT AI Platform',
     description:
         'Comprehensive AI resources covering conversational image editing (Nano Banana), artificial intelligence, generative AI, deep learning, natural language processing (NLP), large language models (LLMs), machine learning tutorials, and AI system guides.',
     keywords: [
@@ -35,8 +34,7 @@ export const metadata: Metadata = {
         'iterative image editing',
     ],
     openGraph: {
-        title:
-            'AI Resources - Learn Conversational Image Editing, Artificial Intelligence & Machine Learning',
+        title: 'AI Resources | VT AI Platform',
         description:
             'Comprehensive resources for learning artificial intelligence, including the revolutionary Nano Banana conversational image editor, generative AI, deep learning, natural language processing, and machine learning.',
         type: 'website',

--- a/apps/web/app/faq/page.tsx
+++ b/apps/web/app/faq/page.tsx
@@ -14,7 +14,7 @@ import type { Metadata } from 'next';
 export const dynamic = 'force-static';
 
 export const metadata: Metadata = {
-    title: 'FAQ - Nano Banana Conversational Image Editing & AI Platform Questions | VT',
+    title: 'AI Platform FAQ | VT',
     description:
         "Frequently asked questions about VT's advanced AI platform featuring the Conversational image editor (Nano Banana), generative AI, deep learning, natural language processing (NLP), large language models (LLMs), and machine learning capabilities. Learn about our revolutionary AI systems.",
     keywords: [
@@ -34,7 +34,7 @@ export const metadata: Metadata = {
         'iterative image editing faq',
     ],
     openGraph: {
-        title: 'FAQ - Nano Banana Conversational Image Editing & AI Platform Questions',
+        title: 'AI Platform FAQ | VT',
         description:
             "Get answers to frequently asked questions about VT's revolutionary AI platform with Nano Banana conversational image editing, generative AI, deep learning, and natural language processing capabilities.",
         type: 'website',

--- a/apps/web/app/help/page.tsx
+++ b/apps/web/app/help/page.tsx
@@ -16,11 +16,11 @@ import {
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-    title: 'Help Center - VT - Nano Banana Image Editing & AI Chat Support',
+    title: 'Help Center | VT AI Platform',
     description:
         'Help center with questions about VT features including Nano Banana conversational image editing, thread isolation, account management, and privacy-focused AI chat capabilities.',
     openGraph: {
-        title: 'Help Center - VT - Nano Banana Image Editing & AI Chat Support',
+        title: 'Help Center | VT AI Platform',
         description:
             'Help center with questions about VT features including Nano Banana conversational image editing and privacy-focused AI chat capabilities.',
         type: 'website',

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -6,7 +6,7 @@ import { PricingClient } from './pricing-client';
 export const dynamic = 'force-static';
 
 export const metadata: Metadata = {
-    title: 'AI Platform Pricing - Advanced Artificial Intelligence Features | VT',
+    title: 'Pricing | VT AI Platform',
     description:
         'VT AI platform pricing: Most artificial intelligence features free with BYOK including generative AI, deep learning, and natural language processing (NLP). VT+ adds professional AI research tools with large language models (LLMs) and machine learning capabilities.',
     keywords: [
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
         'priority access',
     ],
     openGraph: {
-        title: 'AI Platform Pricing - Advanced Artificial Intelligence Features',
+        title: 'Pricing | VT AI Platform',
         description:
             'Most powerful artificial intelligence features free with BYOK including generative AI, deep learning, and natural language processing. VT+ adds professional AI research capabilities with large language models.',
         type: 'website',
@@ -45,7 +45,7 @@ export const metadata: Metadata = {
     },
     twitter: {
         card: 'summary_large_image',
-        title: 'AI Platform Pricing - Advanced Artificial Intelligence Features',
+        title: 'Pricing | VT AI Platform',
         description:
             'Most powerful artificial intelligence features free with BYOK including generative AI, deep learning, and natural language processing. VT+ adds professional AI research capabilities.',
         images: ['https://vtchat.io.vn/twitter-image-v3.jpg'],

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -35,12 +35,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
             priority: 0.8,
         },
         {
-            url: `${baseUrl}/help/faq`,
-            lastModified: oneMonthAgo,
-            changeFrequency: 'monthly',
-            priority: 0.7,
-        },
-        {
             url: `${baseUrl}/ai-resources`,
             lastModified: oneWeekAgo,
             changeFrequency: 'weekly',


### PR DESCRIPTION
## Summary
- shorten page-level metadata titles for the marketing pages to stay within recommended SEO length
- align Open Graph and Twitter titles with the new concise copy for consistency
- remove the non-canonical /help/faq URL from the generated sitemap

## Testing
- bun run fmt
- bun run lint *(fails: existing lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68f36663aea48323aa4ce17a44c14ce0